### PR TITLE
Rectangle shouldn't hold  fraction because Cairo expects double

### DIFF
--- a/src/Roassal3-Trachel/Rectangle.extension.st
+++ b/src/Roassal3-Trachel/Rectangle.extension.st
@@ -2,13 +2,15 @@ Extension { #name : #Rectangle }
 
 { #category : #'*Roassal3-Trachel' }
 Rectangle >> rsCenter [
-	^(origin + corner) / 2
+	^(origin + corner) / 2.0
 ]
 
 { #category : #'*Roassal3-Trachel' }
-Rectangle class >> rsCenter: centerPoint extent: extentPoint [ 
+Rectangle class >> rsCenter: centerPoint extent: extentPoint [
 	"Answer an instance of me whose center is centerPoint and width 
 	by height is extentPoint.  "
 
-	^self origin: centerPoint - (extentPoint/2) extent: extentPoint
+	^ self
+		origin: centerPoint - (extentPoint / 2.0)
+		extent: extentPoint asNonFractionalPoint
 ]


### PR DESCRIPTION
This bug show-stops https://github.com/akevalion/roassalClock.