### PR TITLE
Inherit from correct Spec2 class

### DIFF
--- a/src/Roassal3-Spec/RSMorphicAdapter.class.st
+++ b/src/Roassal3-Spec/RSMorphicAdapter.class.st
@@ -3,7 +3,7 @@ I am bridging RoassalPresenter and RTView
 "
 Class {
 	#name : #RSMorphicAdapter,
-	#superclass : #AbstractMorphicAdapter,
+	#superclass : #SpAbstractMorphicAdapter,
 	#instVars : [
 		'view',
 		'canvas'


### PR DESCRIPTION
Roassal should use the new Spec2 class hierarchy