### PR TITLE
Use key character not key value to support all key boards #114

### DIFF
--- a/src/Roassal3-Interaction/RSKeyNavigationCanvas.class.st
+++ b/src/Roassal3-Interaction/RSKeyNavigationCanvas.class.st
@@ -77,10 +77,10 @@ RSKeyNavigationCanvas >> processKeyDown: evt [
 RSKeyNavigationCanvas >> processKeyUp: evt [
 	| key |
 	steps removeAll.
-	key := evt keyValue.
-	key == 34 "$i" ifTrue: [ ^ self zoomIn: evt ].
-	key == 31 "$o" ifTrue: [ ^ self zoomOut: evt ].
-	key == 46 "$m" ifTrue: [ ^ self expandCollapse: evt ].
+	key := evt keyCharacter.
+	key == $I ifTrue: [ ^ self zoomIn: evt ].
+	key == $O ifTrue: [ ^ self zoomOut: evt ].
+	key == $M ifTrue: [ ^ self expandCollapse: evt ].
 	animation ifNil: [ ^ self ].
 	self removeRectanglesFor: evt canvas.
 	animation stop.


### PR DESCRIPTION
The keyValue in RSKeyUp is not equal for all key boards. So use the keyCharacter instead.

See issue #114 