### PR TITLE
defaultSpec is useless and create bug with the last version of Spec2

### DIFF
--- a/src/Roassal3-Spec/SpRoassalPresenter.class.st
+++ b/src/Roassal3-Spec/SpRoassalPresenter.class.st
@@ -15,14 +15,6 @@ SpRoassalPresenter class >> adapterName [
 	^ #SpMorphicAdapter
 ]
 
-{ #category : #specs }
-SpRoassalPresenter class >> defaultSpec [
-	<spec>
-	
-	^ #(#SpMorphicAdapter
-		adapt: #(model))
-]
-
 { #category : #'instance creation' }
 SpRoassalPresenter class >> open [
 	<script>


### PR DESCRIPTION
I propose to remove the method `defaultSpec`
It should change nothing for the current version of Spec present in the image and it will solve a bug with the last version of Spec (If we load it from the repository)