### PR TITLE
188-Missing-method-comment

### DIFF
--- a/src/Roassal3/RSPropertableObject.class.st
+++ b/src/Roassal3/RSPropertableObject.class.st
@@ -46,6 +46,20 @@ RSPropertableObject >> canvas [
 
 { #category : #events }
 RSPropertableObject >> click [
+	"Simulate a click. 
+	
+For example:
+-=-=-=-=-=-=-=-=-=
+c := RSCanvas new.
+box := RSBox new size: 40.
+box when: RSMouseClick do: [ :evt | self inform: 'hello' ].
+c add: box.
+
+box click.
+
+c
+-=-=-=-=-=-=-=-=-=
+"
 	self announcer announce: (RSMouseClick new).
 ]
 


### PR DESCRIPTION
Added a method coment for the method `click`.Fix #188