### PR TITLE
156-SearchInCanvas-does-not-work-when-highlightable-is-used

### DIFF
--- a/src/Roassal3-Interaction-Tests/RSSearchInCanvasTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSSearchInCanvasTest.class.st
@@ -37,10 +37,10 @@ RSSearchInCanvasTest >> testBasic [
 	self assert: shapes fifth color = Color gray.
 	
 	search searchForShapes: '*5*'.
-	self assert: shapes fourth color ~= Color gray.
+	self assert: shapes fourth color == Color gray.
 	self assert: shapes fifth color ~= Color gray.
 	
-	self assert: search numberOfHighlightedShapes equals: 2.
+	self assert: search numberOfHighlightedShapes equals: 1.
 
 	search resetAllHighlightedShapes.
 	self assert: shapes fourth color = Color gray.

--- a/src/Roassal3-Interaction/RSHighlightable.class.st
+++ b/src/Roassal3-Interaction/RSHighlightable.class.st
@@ -48,14 +48,14 @@ Class {
 	#superclass : #RSInteraction,
 	#instVars : [
 		'announcer',
-		'attributeKey',
 		'copyKey',
-		'highlightShapes'
+		'highlightShapes',
+		'propertyKey'
 	],
 	#category : #'Roassal3-Interaction-Core'
 }
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
 RSHighlightable class >> defaultRed [
 	| inst |
 	inst := self new.
@@ -190,16 +190,23 @@ RSHighlightable >> highlightShapes: aBlock [
 ]
 
 { #category : #'highlight shapes' }
-RSHighlightable >> highlightShapes: aBlock butKeep: aRSHilightable [
+RSHighlightable >> highlightShapes: aBlock butKeep: aRSHighlightable [
 	"aBlock recives an element and return a collection of shapes"
 	self highlightShapes: [ :e | 
 		| shapes |
 		shapes := aBlock value: e.
 		e canvas properties
-			at: aRSHilightable propertyKey
+			at: aRSHighlightable propertyKey
 			ifPresent: [ :hshapes | 
 				shapes reject: [ :hs | hshapes includes: hs ] ]
 			ifAbsent: [ shapes ] ]
+]
+
+{ #category : #'highlight shapes' }
+RSHighlightable >> highlightShapesButKeep: aRSHighlightable [
+	self 
+		highlightShapes: [ :e | { e } ]
+		butKeep: aRSHighlightable
 ]
 
 { #category : #'accessing - computed' }
@@ -231,12 +238,12 @@ RSHighlightable >> onShape: aShape [
 
 { #category : #'accessing - keys' }
 RSHighlightable >> propertyKey [
-	^ attributeKey ifNil: [ attributeKey := #highlightShapes ].
+	^ propertyKey ifNil: [ propertyKey := self hash asString ]
 ]
 
 { #category : #'accessing - keys' }
 RSHighlightable >> propertyKey: aSymbol [
-	attributeKey := aSymbol.
+	propertyKey := aSymbol.
 ]
 
 { #category : #private }

--- a/src/Roassal3-Interaction/RSSearchInCanvas.class.st
+++ b/src/Roassal3-Interaction/RSSearchInCanvas.class.st
@@ -22,10 +22,9 @@ Class {
 	#name : #RSSearchInCanvas,
 	#superclass : #RSAbstractControlCanvas,
 	#instVars : [
-		'highlightedShapes',
 		'canvas',
-		'colorToHighlight',
-		'useExactMatch'
+		'useExactMatch',
+		'highlightable'
 	],
 	#category : #'Roassal3-Interaction-Controls'
 }
@@ -53,7 +52,9 @@ RSSearchInCanvas >> canvas: aCanvas [
 { #category : #'public - configuration' }
 RSSearchInCanvas >> colorToHighlight: aColor [
 	"Set the color to highlight shapes when searching"
-	colorToHighlight := aColor
+	highlightable := RSHighlightable new
+		highlightColor: aColor;
+		yourself.
 ]
 
 { #category : #'public - configuration' }
@@ -63,15 +64,13 @@ RSSearchInCanvas >> doNotUseExactMatch [
 ]
 
 { #category : #util }
-RSSearchInCanvas >> highlightShape: s [
-	"Highlight a shape. Remember it in case we need to unlighted"
-	highlightedShapes add: s.
-	^ RSHighlightable new record: s selector: #color value: colorToHighlight
-]
-
-{ #category : #util }
 RSSearchInCanvas >> highlightShapes: shapesToHighlight [
 	shapesToHighlight do: [ :s | self highlightShape: s ]
+]
+
+{ #category : #accessing }
+RSSearchInCanvas >> highlightable [
+	^ highlightable
 ]
 
 { #category : #initialization }
@@ -79,9 +78,9 @@ RSSearchInCanvas >> initialize [
 	super initialize.
 
 	"The variable highlightedShapes contains the shapes that have been searched and therefore highlighted"
-	highlightedShapes := OrderedCollection new.
-	colorToHighlight := Color red.
-	self doNotUseExactMatch
+	self 
+		colorToHighlight: Color red;
+		doNotUseExactMatch
 ]
 
 { #category : #util }
@@ -92,18 +91,20 @@ RSSearchInCanvas >> isRegExpValid: regExp [
 
 { #category : #configuration }
 RSSearchInCanvas >> keyForReset [
-	^ 'r'
+	^ 'R'
 ]
 
 { #category : #configuration }
 RSSearchInCanvas >> keyForSearch [
-	^ 's'
+	^ 'S'
 ]
 
 { #category : #util }
 RSSearchInCanvas >> numberOfHighlightedShapes [
 	"Return the number of shapes that have been highlited"
-	^ highlightedShapes size
+	^ (canvas propertyAt: highlightable propertyKey)
+		ifNil: [ 0 ]
+		ifNotNil: [ :col | col size ]
 ]
 
 { #category : #private }
@@ -142,9 +143,8 @@ RSSearchInCanvas >> renderLegendOn: aLegendBuilder [
 { #category : #public }
 RSSearchInCanvas >> resetAllHighlightedShapes [
 	"Restore the colors of all the highlighted shapes"
-	self unhighlightShapes: highlightedShapes.
-	highlightedShapes := OrderedCollection new.
-	canvas signalUpdate
+	highlightable unhighlightRecordedShapes: canvas.
+	canvas signalUpdate.
 ]
 
 { #category : #public }
@@ -166,7 +166,7 @@ RSSearchInCanvas >> searchForShapes: regExp [
 	"No need to pursue if we have not found anything"
 	shapesToHighlight ifEmpty: [ ^ self ].
 	
-	self highlightShapes: shapesToHighlight.
+	highlightable doHighlightShapes: shapesToHighlight.
 	canvas signalUpdate
 ]
 


### PR DESCRIPTION
This PR container a modified version of `RSSearchInCanvas`. this class now uses a `RSHighlightable`.I think that we can put some operations between instances of RSHighlightable