### PR TITLE
206-RPackagedependentPackages-does-not-consider-class-extensions

### DIFF
--- a/src/Roassal3-Examples/RPackage.extension.st
+++ b/src/Roassal3-Examples/RPackage.extension.st
@@ -7,7 +7,7 @@ RPackage >> dependentPackages [
 	
 	(RPackageOrganizer default packageNamed: 'Roassal3') dependentPackages
 	"
-	^ (self definedClasses flatCollect: #dependentClasses) collect: #package as: Set
+	^ (self definedClasses flatCollect: #dependentClasses), self extendedClasses collect: #package as: Set
 ]
 
 { #category : #'*Roassal3-Examples' }

--- a/src/Roassal3-Global-Tests/RSDependencyTest.class.st
+++ b/src/Roassal3-Global-Tests/RSDependencyTest.class.st
@@ -8,9 +8,8 @@ Class {
 RSDependencyTest >> assertPackage: p1Name dependOn: p2Name [
 
 	| p1 p2 |
-	p1 := RPackageOrganizer default packageNamed: p1Name.
-	p2 := RPackageOrganizer default packageNamed: p2Name.
-	
+	p1 := self packageNamed: p1Name.
+	p2 := self packageNamed: p2Name.
 	self assert: (p1 dependentPackages includes: p2).
 ]
 
@@ -18,10 +17,21 @@ RSDependencyTest >> assertPackage: p1Name dependOn: p2Name [
 RSDependencyTest >> assertPackage: p1Name doesNotDependOn: p2Name [
 
 	| p1 p2 |
-	p1 := RPackageOrganizer default packageNamed: p1Name.
-	p2 := RPackageOrganizer default packageNamed: p2Name.
-	
+	p1 := self packageNamed: p1Name.
+	p2 := self packageNamed: p2Name.
 	self deny: (p1 dependentPackages includes: p2).
+]
+
+{ #category : #testing }
+RSDependencyTest >> hasPackage: aString [ 
+	
+	^ (self packageNamed: aString) notNil.
+]
+
+{ #category : #tests }
+RSDependencyTest >> packageNamed: aSymbol [
+	^ RPackageOrganizer default packageNamed: aSymbol 
+		ifAbsent: [ nil ]
 ]
 
 { #category : #tests }
@@ -33,7 +43,11 @@ RSDependencyTest >> testDependencies [
 	self assertPackage: 'Roassal3' doesNotDependOn: 'Roassal3-Chart'.
 	self assertPackage: 'Roassal3' doesNotDependOn: 'Roassal3-Colors'.
 	self assertPackage: 'Roassal3-Shapes' doesNotDependOn: 'Roassal3-Layouts'.
-	
+	self assertPackage: 'Roassal3-Animation' dependOn: 'Roassal3'.
+
 	"Chart uses RSLocation from Layouts"
 	self assertPackage: 'Roassal3-Chart' dependOn: 'Roassal3-Layouts'.
+	"not a core package then we can not depent on this package"
+	(self hasPackage: 'Roassal3-Spec-Examples') ifFalse: [ ^ self ].
+	self assertPackage: 'Roassal3-Spec-Examples' dependOn: 'Roassal3-Menu'.
 ]


### PR DESCRIPTION
Update for issue #206, now `dependentPackages` consider extentions