### PR TITLE
Remove RSLine>>delta global state

### DIFF
--- a/src/Roassal3-Shapes-Tests/RSLinesTest.class.st
+++ b/src/Roassal3-Shapes-Tests/RSLinesTest.class.st
@@ -49,9 +49,27 @@ RSLinesTest >> testDrawMarkers [
 ]
 
 { #category : #running }
-RSLinesTest >> testPolyline [
+RSLinesTest >> testLineIncludesPoint [
+	| line |
+	line := RSLine new
+		startPoint: 0@0;
+		endPoint: 0@100;
+		width: 8;
+		yourself.
+	self assert: (line includesPoint: 0@0).
+	self assert: (line includesPoint: 0@100).
+	self assert: (line includesPoint: 0@50).
+	self assert: (line includesPoint: 4@50).
+	self deny: (line includesPoint: 5@50).
+	self deny: (line includesPoint: 500@500).
+
+]
+
+{ #category : #running }
+RSLinesTest >> testPolylineIncludesPoint [
 	| line |
 	line := RSPolyline new.
+	line width: 10.
 	line controlPoints: { 0@0. 0@100 }.
 	self assert: (line includesPoint: 0@0).
 	self assert: (line includesPoint: 0@100).
@@ -60,14 +78,4 @@ RSLinesTest >> testPolyline [
 	
 	self deny: (line includesPoint: 500@500).
 	self deny: (line includesPoint: 6@50).
-]
-
-{ #category : #running }
-RSLinesTest >> testPolylineBasic [
-	| line |
-	line := RSPolyline new.
-	
-	self deny: (line includesPoint: 500@500).
-	self deny: (line includesPoint: 6@50).
-	self assert: line controlPoints equals: { 0@0. 0@0 }.
 ]

--- a/src/Roassal3-Shapes/RSAbstractLine.class.st
+++ b/src/Roassal3-Shapes/RSAbstractLine.class.st
@@ -134,6 +134,11 @@ RSAbstractLine >> hasMarkers [
 		m anySatisfy: [ :mar | mar notNil ].  ]
 ]
 
+{ #category : #accessing }
+RSAbstractLine >> includedRadius [
+	^ self border width / 2
+]
+
 { #category : #initialization }
 RSAbstractLine >> initialize [ 
 	super initialize.

--- a/src/Roassal3-Shapes/RSLine.class.st
+++ b/src/Roassal3-Shapes/RSLine.class.st
@@ -32,28 +32,8 @@ Adding single line can be complex in some situation. You may want to look at RSE
 Class {
 	#name : #RSLine,
 	#superclass : #RSAbstractDualLine,
-	#classInstVars : [
-		'delta'
-	],
 	#category : #'Roassal3-Shapes-Lines'
 }
-
-{ #category : #accessing }
-RSLine class >> delta [
-	^ delta ifNil: [ delta := 5 ]
-]
-
-{ #category : #accessing }
-RSLine class >> delta: aNumber [
-	self assert: aNumber >= 0 description: 'The delta for TSLine can not be negative'.
-	delta := aNumber
-]
-
-{ #category : #accessing }
-RSLine class >> reset [
-	<script: 'self reset'>
-	delta := nil.
-]
 
 { #category : #visiting }
 RSLine >> buildPathOn: visitor [
@@ -62,9 +42,10 @@ RSLine >> buildPathOn: visitor [
 
 { #category : #testing }
 RSLine >> includesPoint: aPoint [
+	self hasBorder ifFalse: [ ^ false ].
+	 
 	^ aPoint
 		onLineFrom: self startPoint 
 		to: self endPoint 
-		within: RSLine delta
-	
+		within: self includedRadius
 ]

--- a/src/Roassal3-Shapes/RSPolyline.class.st
+++ b/src/Roassal3-Shapes/RSPolyline.class.st
@@ -27,11 +27,11 @@ RSPolyline >> cornerRadii: aNumber [
 
 { #category : #testing }
 RSPolyline >> includesPoint: aPoint [
-	| cp |
-	cp := self controlPoints.
-	1 to: cp size - 1 do: [ :i | | p2 p1|
-		p1 := cp at: i.
-		p2 := cp at: i + 1.
-		(aPoint onLineFrom: p1 to: p2 within: RSLine delta) ifTrue: [ ^ true ] ].
-	^ false.
+	"Answer whether any segment of this polyline includes aPoint."
+
+	self hasBorder ifFalse: [ ^ false ].
+	self controlPoints overlappingPairsDo: [ :a :b | 
+		(aPoint onLineFrom: a to: b within: self includedRadius)
+			ifTrue: [ ^ true ] ].
+	^ false
 ]

--- a/src/Roassal3/RSShape.class.st
+++ b/src/Roassal3/RSShape.class.st
@@ -202,7 +202,8 @@ RSShape >> height [
 
 { #category : #testing }
 RSShape >> includesPoint: aPoint [
-	"Return true or false"
+	"Answer whether this shape includes aPoint."
+
 	^ false
 ]
 


### PR DESCRIPTION
May need some minimum value when border width
is too small in the canvas and can be difficult to point
the line with the cursor.

Tries to fix #228.

Try this code:
~~~smalltalk
canvas := RSCanvas new.
c := RSComposite new.

i := RSHighlightable defaultRed.
#(0.1 1 10 15) doWithIndex: [ :width :index |
    c add: (RSLine new
        @ i;
        startPoint: index * 15 @ 0;
        endPoint: index * 15 @ 100;
        width: width;
        yourself).
     ].

c adjustToChildren.
c extent: (100@100).
c scaleBy: 10.
c rotateByDegrees: 45.
c color: Color blue.

canvas addShape: c.
canvas @ RSCanvasController.

canvas.
~~~