### PR TITLE
Refactoring in RSAbstractControlCanvas hierarchy

### DIFF
--- a/src/Roassal3-Interaction/RSAbstractControlCanvas.class.st
+++ b/src/Roassal3-Interaction/RSAbstractControlCanvas.class.st
@@ -21,18 +21,17 @@ RSAbstractControlCanvas >> configuration: aRSControlLimits [
 ]
 
 { #category : #utilities }
-RSAbstractControlCanvas >> correctCameraPosition: evt [ 
+RSAbstractControlCanvas >> correctCameraPosition: aCanvas [ 
 	^ self 
-		correctCameraPosition: evt
-		inRectangle: (self expandedRectangle: evt)
-		position: evt camera position
-		scale: evt camera scale
+		correctCameraPosition: aCanvas
+		inRectangle: (self expandedRectangle: aCanvas)
+		position: aCanvas camera position
+		scale: aCanvas camera scale
 ]
 
 { #category : #utilities }
-RSAbstractControlCanvas >> correctCameraPosition: evt inRectangle: rectangle position: position scale: scale [
-	| aCanvas canvasRect x y p |
-	aCanvas := evt canvas.
+RSAbstractControlCanvas >> correctCameraPosition: aCanvas inRectangle: rectangle position: position scale: scale [
+	| canvasRect x y p |
 	p := position.
 	canvasRect := Rectangle
 		floatCenter: p
@@ -63,11 +62,11 @@ RSAbstractControlCanvas >> correctCameraPosition: evt inRectangle: rectangle pos
 ]
 
 { #category : #utilities }
-RSAbstractControlCanvas >> correctCameraPosition: evt scale: scale [
+RSAbstractControlCanvas >> correctCameraPosition: aCanvas scale: scale [
 	^ self 
-		correctCameraPosition: evt
-		inRectangle: (self expandedRectangle: evt)
-		position: evt camera position
+		correctCameraPosition: aCanvas
+		inRectangle: (self expandedRectangle: aCanvas)
+		position: aCanvas camera position
 		scale: scale
 ]
 
@@ -78,12 +77,12 @@ RSAbstractControlCanvas >> encompassingRectangleFor: aCanvas [
 ]
 
 { #category : #utilities }
-RSAbstractControlCanvas >> expandedRectangle: evt [
+RSAbstractControlCanvas >> expandedRectangle: aCanvas [
 	| key | 
 	key := #expanedEncompassingRectangle.
-	^ evt canvas propertyAt: key ifAbsentPut: [ 
+	^ aCanvas propertyAt: key ifAbsentPut: [ 
 		| rectangle |
-		rectangle := self encompassingRectangleFor: evt canvas.
+		rectangle := self encompassingRectangleFor: aCanvas.
 		self configuration padding expandRectangle: rectangle ].
 	
 ]

--- a/src/Roassal3-Interaction/RSDraggableCanvas.class.st
+++ b/src/Roassal3-Interaction/RSDraggableCanvas.class.st
@@ -89,7 +89,7 @@ RSDraggableCanvas >> mouseEnd: evt [
 	delta := lastStep * 2.5.
 	lastStep := nil.
 	camera translateBy: delta.
-	correct := self correctCameraPosition: evt.
+	correct := self correctCameraPosition: aCanvas.
 	camera translateBy: delta negated.
 			
 	p := (correct - camera position) abs max: 1@1.
@@ -121,7 +121,7 @@ RSDraggableCanvas >> mouseMove: evt [
 	isMoving ifFalse: [ ^ self ].
 	camera := evt camera.
 	lastStep := evt step negated / camera scale.
-	correct  := self correctCameraPosition: evt.
+	correct  := self correctCameraPosition: evt canvas.
 	p := (correct - camera position) abs max: 1@1.
 	p := p x sqrt @ p y sqrt.
 	camera translateBy: lastStep/ p.

--- a/src/Roassal3-Interaction/RSKeyNavigationCanvas.class.st
+++ b/src/Roassal3-Interaction/RSKeyNavigationCanvas.class.st
@@ -36,10 +36,10 @@ RSKeyNavigationCanvas >> onShape: aCanvas [
 
 { #category : #events }
 RSKeyNavigationCanvas >> processKeyDown: evt [
-	| keyName rect lastMS |
+	| keyName |
 	keyName := evt keyName.
-	keyName = #I ifTrue: [ ^ self zoomIn: evt ].
-	keyName = #O ifTrue: [ ^ self zoomOut: evt ].
+	keyName = #I ifTrue: [ ^ self zoomIn: evt canvas ].
+	keyName = #O ifTrue: [ ^ self zoomOut: evt canvas ].
 	self configuration hasHorizontalScrolling ifTrue: [ 
 		keyName = #KP_LEFT ifTrue: [ steps add: -1@0 ].
 		keyName = #KP_RIGHT ifTrue: [ steps add: 1@0 ].
@@ -54,25 +54,7 @@ RSKeyNavigationCanvas >> processKeyDown: evt [
 		ifFalse: [ 1 ].
 	animation ifNotNil: [ ^ self ].
 	steps ifEmpty: [ ^ self ].
-	rect := self encompassingRectangleFor: evt canvas.
-	speed := (rect width min: rect height) * 0.0005.
-	animation := nil.
-	lastMS := nil.
-	animation := evt canvas newAnimation repeat onStepDo: [ :t |
-		| step camera correct position deltaMS current |
-		current := animation currentTime.
-		lastMS ifNil: [ lastMS := current-1 ].
-		deltaMS := current - lastMS.
-		lastMS := current.
-		step := steps inject: 0@0 into: [:p :s |p+s ].
-		camera := evt camera.
-		camera translateBy: step / (evt canvas camera scale / (speed * speedMult * deltaMS)).
-		position := camera position.
-		correct := self correctCameraPosition: evt.
-		correct = position 
-			ifFalse: [ camera position: correct ].
-		evt signalUpdate.
-		].
+	self processStepsOn: evt canvas
 ]
 
 { #category : #events }
@@ -89,6 +71,31 @@ RSKeyNavigationCanvas >> processKeyUp: evt [
 	animation := nil.
 ]
 
+{ #category : #events }
+RSKeyNavigationCanvas >> processStepsOn: aCanvas [
+
+	| rect lastMS |
+	rect := self encompassingRectangleFor: aCanvas.
+	speed := (rect width min: rect height) * 0.0005.
+	animation := nil.
+	lastMS := nil.
+	animation := aCanvas newAnimation repeat onStepDo: [ :t |
+		| step camera correct position deltaMS current |
+		current := animation currentTime.
+		lastMS ifNil: [ lastMS := current-1 ].
+		deltaMS := current - lastMS.
+		lastMS := current.
+		step := steps inject: 0@0 into: [:p :s |p+s ].
+		camera := aCanvas camera.
+		camera translateBy: step / (aCanvas camera scale / (speed * speedMult * deltaMS)).
+		position := camera position.
+		correct := self correctCameraPosition: aCanvas.
+		correct = position 
+			ifFalse: [ camera position: correct ].
+		aCanvas signalUpdate.
+		].
+]
+
 { #category : #rendering }
 RSKeyNavigationCanvas >> renderLegendOn: lb [
 	lb
@@ -100,27 +107,27 @@ RSKeyNavigationCanvas >> renderLegendOn: lb [
 ]
 
 { #category : #'events-processing' }
-RSKeyNavigationCanvas >> zoomIn: evt [
-	self zoomMove: evt delta: 1.5
+RSKeyNavigationCanvas >> zoomIn: aCanvas [
+	self zoomMove: aCanvas delta: 1.5
 ]
 
 { #category : #'events-processing' }
-RSKeyNavigationCanvas >> zoomMove: evt delta: delta [
+RSKeyNavigationCanvas >> zoomMove: aCanvas delta: delta [
 	| scale camera newScale correct |
-	camera := evt camera.
+	camera := aCanvas camera.
 	scale := camera scale.
 	newScale := self scaleFor: delta * scale. 
-	evt canvas newAnimation 
+	aCanvas newAnimation 
 		easing: RSEasing backOut;
 		duration: 200 milliSeconds;
 		from: scale;
 		to: newScale;
 		on: camera set: #scale:.
 	correct := self 
-		correctCameraPosition: evt
+		correctCameraPosition: aCanvas
 		scale: newScale.
 	correct = camera position ifTrue: [ ^ self ].
-	evt canvas newAnimation 
+	aCanvas newAnimation 
 		easing: RSEasing backOut;
 		duration: 200 milliSeconds;
 		from: camera position;
@@ -129,7 +136,7 @@ RSKeyNavigationCanvas >> zoomMove: evt delta: delta [
 ]
 
 { #category : #'events-processing' }
-RSKeyNavigationCanvas >> zoomOut: evt [
-	self zoomMove: evt delta: 0.5.
+RSKeyNavigationCanvas >> zoomOut: aCanvas [
+	self zoomMove: aCanvas delta: 0.5.
 	
 ]

--- a/src/Roassal3-Interaction/RSScrollWheelCanvas.class.st
+++ b/src/Roassal3-Interaction/RSScrollWheelCanvas.class.st
@@ -10,6 +10,34 @@ Class {
 	#category : #'Roassal3-Interaction-Controls'
 }
 
+{ #category : #'events-processing' }
+RSScrollWheelCanvas >> move: aCanvas delta: delta [
+
+	| correct p |
+	correct := self correctCameraPosition: aCanvas.
+	p := (correct - aCanvas camera position) abs max: 1@1.
+	p := p x sqrt @ p y sqrt.
+	aCanvas camera translateBy: (0@ delta)/p.
+	aCanvas signalUpdate.
+	
+	animation ifNotNil: [ animation stop ].
+	animation := aCanvas newAnimation
+		duration: 300 milliSeconds;
+		onStepDo: [ :t | aCanvas signalUpdate ];
+		when: RSAnimationLoopEvent do: [ :e | 
+			aCanvas newAnimation
+				duration: 200 milliSeconds;
+				from: aCanvas camera position;
+				to: (self correctCameraPosition: aCanvas);
+				onStepDo: [ :t | 
+					aCanvas camera translateTo: t.
+					aCanvas signalUpdate ].
+			].
+	
+	
+	
+]
+
 { #category : #hooks }
 RSScrollWheelCanvas >> onShape: aCanvas [
 	aCanvas when: RSMouseWheelEvent do: [ :evt | self processEvent: evt ]
@@ -17,33 +45,12 @@ RSScrollWheelCanvas >> onShape: aCanvas [
 
 { #category : #'events-processing' }
 RSScrollWheelCanvas >> processEvent: evt [
-	| delta correct p |
+	| delta |
 	delta := (evt isUp
 		ifTrue: [ -1]
 		ifFalse: [ 1 ]) * 30.
-	correct := self correctCameraPosition: evt.
-	p := (correct - evt camera position) abs max: 1@1.
-	p := p x sqrt @ p y sqrt.
-	evt camera translateBy: (0@ delta)/p.
-	evt signalUpdate.
-	
-	animation ifNotNil: [ animation stop ].
-	animation := evt canvas newAnimation
-		duration: 300 milliSeconds;
-		onStepDo: [ :t | evt canvas signalUpdate ];
-		when: RSAnimationLoopEvent do: [ :e | 
-			evt canvas newAnimation
-				duration: 200 milliSeconds;
-				from: evt camera position;
-				to: (self correctCameraPosition: evt);
-				onStepDo: [ :t | 
-					evt camera translateTo: t.
-					evt signalUpdate
-					 ].
-			].
-	
-	
-	
+		
+	self move: evt canvas delta: delta.
 ]
 
 { #category : #rendering }

--- a/src/Roassal3-Interaction/RSZoomableCanvas.class.st
+++ b/src/Roassal3-Interaction/RSZoomableCanvas.class.st
@@ -10,6 +10,31 @@ Class {
 	#category : #'Roassal3-Interaction-Controls'
 }
 
+{ #category : #'events-processing' }
+RSZoomableCanvas >> move: aCanvas evtPosition: evtPosition delta: delta [
+
+	| camera sc dist correct scale position |
+	camera := aCanvas camera.
+	sc := camera scale * delta x.
+	sc = (self scaleFor: sc) ifFalse: [ ^ self ].
+	dist := evtPosition - camera position.
+	correct := self
+		correctCameraPosition: aCanvas 
+		inRectangle: (self expandedRectangle: aCanvas)
+		position: camera position + (dist * delta y)
+		scale: sc.
+	scale := NSScale sqrt range: { camera scale. sc }.
+	position := NSScale sqrt range: { camera position. correct }.
+	animation := aCanvas newAnimation
+		duration: 200 milliSeconds;
+		onStepDo: [ :t |
+			camera 
+				scale: (scale scale: t);
+				translateTo: (position scale: t).
+			aCanvas signalUpdate ];
+		when: RSAnimationEndEvent do: [ animation := nil ]
+]
+
 { #category : #hooks }
 RSZoomableCanvas >> onShape: aCanvas [
 	aCanvas when: RSMouseWheelEvent do: [ :evt | self processEvent: evt ]
@@ -17,30 +42,12 @@ RSZoomableCanvas >> onShape: aCanvas [
 
 { #category : #'events-processing' }
 RSZoomableCanvas >> processEvent: evt [
-	| sc delta camera dist scale position correct |
+	| delta |
 	animation ifNotNil: [ ^ self ].
 	delta := evt isUp
 		ifTrue: [ 1.25@0.2 ]
 		ifFalse: [ 0.8@ -0.25 ].
-	camera := evt camera.
-	sc := camera scale * delta x.
-	sc = (self scaleFor: sc) ifFalse: [ ^ self ].
-	dist := evt position - camera position.
-	correct := self
-		correctCameraPosition: evt 
-		inRectangle: (self expandedRectangle: evt)
-		position: camera position + (dist * delta y)
-		scale: sc.
-	scale := NSScale sqrt range: { camera scale. sc }.
-	position := NSScale sqrt range: { camera position. correct }.
-	animation := evt canvas newAnimation
-		duration: 200 milliSeconds;
-		onStepDo: [ :t |
-			camera 
-				scale: (scale scale: t);
-				translateTo: (position scale: t).
-			evt signalUpdate ];
-		when: RSAnimationEndEvent do: [ animation := nil ]
+	self move: evt canvas evtPosition: evt position delta: delta.
 ]
 
 { #category : #rendering }


### PR DESCRIPTION
I decided to do this refactoring to be able to execute "externally" some useful methods in this hierarchy. 

Concretely:

I had the idea to do this change when I discovered that this was already possible to be done (and was cool):
~~~Smalltalk
RSZoomToFitCanvas new animatedZoomToFit: canvas.
~~~

But with this refactoring, you can also do this:
~~~Smalltalk
RSKeyNavigationCanvas new zoomIn: canvas.
RSKeyNavigationCanvas new zoomOut: canvas.
~~~
