### PR TITLE
reset cached encompassingRectangle when baseRectangle is recalculated…

### DIFF
--- a/src/Roassal3-Shapes/RSBitmap.class.st
+++ b/src/Roassal3-Shapes/RSBitmap.class.st
@@ -14,7 +14,8 @@ Class {
 RSBitmap >> computeRectangle [
 	baseRectangle := Rectangle floatCenter: 0@0 extent: (form 
 		ifNil: [ 0@0 ]
-		ifNotNil: [ form extent ])
+		ifNotNil: [ form extent ]).
+	encompassingRectangle := nil
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
… in the RSBitmap

fixes #337 