### PR TITLE
Renaming of RSMockElement to RSMockShape

### DIFF
--- a/src/Roassal3-Layouts/RSForceBasedLayout.class.st
+++ b/src/Roassal3-Layouts/RSForceBasedLayout.class.st
@@ -247,7 +247,7 @@ RSForceBasedLayout >> newMockEdgeFor: e [
 
 { #category : #'private - initialization' }
 RSForceBasedLayout >> newMockElementFor: e [
-	^ RSMockElement new
+	^ RSMockShape new
 		realElement: e;
 		charge: charge;
 		weight: 0;

--- a/src/Roassal3-Layouts/RSMockElement.class.st
+++ b/src/Roassal3-Layouts/RSMockElement.class.st
@@ -1,131 +1,13 @@
 "
-TODO
+TODO.
 "
 Class {
 	#name : #RSMockElement,
-	#superclass : #RSObject,
-	#instVars : [
-		'realElement',
-		'position',
-		'weight',
-		'oldPosition',
-		'isFixed',
-		'fixPosition',
-		'charge'
-	],
+	#superclass : #RSMockShape,
 	#category : #'Roassal3-Layouts-Utils'
 }
 
-{ #category : #actions }
-RSMockElement >> addWeight [
-	weight := weight + 1
-]
-
-{ #category : #actions }
-RSMockElement >> applyToRealElement [
-	isFixed ifTrue: [ ^ self ].
-	realElement translateTo: position 
-]
-
-{ #category : #accessing }
-RSMockElement >> canvas [
-	^ realElement canvas
-]
-
-{ #category : #accessing }
-RSMockElement >> charge [
-	^ charge
-]
-
-{ #category : #accessing }
-RSMockElement >> charge: aNum [
-	charge := aNum
-]
-
-{ #category : #accessing }
-RSMockElement >> encompassingRectangle [ 
-	^ realElement encompassingRectangle
-]
-
-{ #category : #accessing }
-RSMockElement >> extent [
-	^ realElement extent
-]
-
-{ #category : #accessing }
-RSMockElement >> fixPosition [
-	^ fixPosition
-]
-
-{ #category : #accessing }
-RSMockElement >> fixPosition: aPoint [
-	fixPosition := aPoint
-]
-
-{ #category : #accessing }
-RSMockElement >> height [
-	^ realElement height
-]
-
-{ #category : #actions }
-RSMockElement >> initialize [
-	super initialize.
-	isFixed := false.
-]
-
-{ #category : #accessing }
-RSMockElement >> isFixed [
-	^ isFixed 
-]
-
-{ #category : #accessing }
-RSMockElement >> isFixed: aBool [
-	isFixed := aBool
-]
-
-{ #category : #accessing }
-RSMockElement >> oldPosition [
-	^ oldPosition
-]
-
-{ #category : #accessing }
-RSMockElement >> oldPosition: aPoint [
-	oldPosition := aPoint
-]
-
-{ #category : #accessing }
-RSMockElement >> position [
-	^ position
-]
-
-{ #category : #accessing }
-RSMockElement >> realElement [
-	^ realElement
-]
-
-{ #category : #accessing }
-RSMockElement >> realElement: rtElement [
-	realElement := rtElement.
-	position := rtElement position.
-	self oldPosition: position.
-]
-
-{ #category : #actions }
-RSMockElement >> translateTo: aPosition [
-	position := aPosition
-]
-
-{ #category : #accessing }
-RSMockElement >> weight [
-	^ weight
-]
-
-{ #category : #accessing }
-RSMockElement >> weight: aNumber [
-	weight := aNumber
-]
-
-{ #category : #accessing }
-RSMockElement >> width [
-	^ realElement width
+{ #category : #testing }
+RSMockElement class >> isDeprecated [ 
+	^ true
 ]

--- a/src/Roassal3-Layouts/RSMockShape.class.st
+++ b/src/Roassal3-Layouts/RSMockShape.class.st
@@ -1,0 +1,131 @@
+"
+TODO
+"
+Class {
+	#name : #RSMockShape,
+	#superclass : #RSObject,
+	#instVars : [
+		'realElement',
+		'position',
+		'weight',
+		'oldPosition',
+		'isFixed',
+		'fixPosition',
+		'charge'
+	],
+	#category : #'Roassal3-Layouts-Utils'
+}
+
+{ #category : #actions }
+RSMockShape >> addWeight [
+	weight := weight + 1
+]
+
+{ #category : #actions }
+RSMockShape >> applyToRealElement [
+	isFixed ifTrue: [ ^ self ].
+	realElement translateTo: position 
+]
+
+{ #category : #accessing }
+RSMockShape >> canvas [
+	^ realElement canvas
+]
+
+{ #category : #accessing }
+RSMockShape >> charge [
+	^ charge
+]
+
+{ #category : #accessing }
+RSMockShape >> charge: aNum [
+	charge := aNum
+]
+
+{ #category : #accessing }
+RSMockShape >> encompassingRectangle [ 
+	^ realElement encompassingRectangle
+]
+
+{ #category : #accessing }
+RSMockShape >> extent [
+	^ realElement extent
+]
+
+{ #category : #accessing }
+RSMockShape >> fixPosition [
+	^ fixPosition
+]
+
+{ #category : #accessing }
+RSMockShape >> fixPosition: aPoint [
+	fixPosition := aPoint
+]
+
+{ #category : #accessing }
+RSMockShape >> height [
+	^ realElement height
+]
+
+{ #category : #actions }
+RSMockShape >> initialize [
+	super initialize.
+	isFixed := false.
+]
+
+{ #category : #accessing }
+RSMockShape >> isFixed [
+	^ isFixed 
+]
+
+{ #category : #accessing }
+RSMockShape >> isFixed: aBool [
+	isFixed := aBool
+]
+
+{ #category : #accessing }
+RSMockShape >> oldPosition [
+	^ oldPosition
+]
+
+{ #category : #accessing }
+RSMockShape >> oldPosition: aPoint [
+	oldPosition := aPoint
+]
+
+{ #category : #accessing }
+RSMockShape >> position [
+	^ position
+]
+
+{ #category : #accessing }
+RSMockShape >> realElement [
+	^ realElement
+]
+
+{ #category : #accessing }
+RSMockShape >> realElement: rtElement [
+	realElement := rtElement.
+	position := rtElement position.
+	self oldPosition: position.
+]
+
+{ #category : #actions }
+RSMockShape >> translateTo: aPosition [
+	position := aPosition
+]
+
+{ #category : #accessing }
+RSMockShape >> weight [
+	^ weight
+]
+
+{ #category : #accessing }
+RSMockShape >> weight: aNumber [
+	weight := aNumber
+]
+
+{ #category : #accessing }
+RSMockShape >> width [
+	^ realElement width
+]


### PR DESCRIPTION
RSMockElement is now a deprecated subclass of RSMockShape
With the same comment.