### PR TITLE
Continue the Roassal3 renamings

### DIFF
--- a/src/Roassal3-Animation-Tests/RSEasingInterpolatorTest.class.st
+++ b/src/Roassal3-Animation-Tests/RSEasingInterpolatorTest.class.st
@@ -1,15 +1,15 @@
 Class {
-	#name : #RSEasingTest,
+	#name : #RSEasingInterpolatorTest,
 	#superclass : #TestCase,
 	#category : #'Roassal3-Animation-Tests'
 }
 
 { #category : #tests }
-RSEasingTest >> testAllEasing [
+RSEasingInterpolatorTest >> testAllEasing [
 	"Simply check if no error is raised"
 	| someX |
 	someX := (0 to: 1 by: 0.01).
-	RSEasing allSubclassesDo: [ :cls |
+	RSEasingInterpolator allSubclassesDo: [ :cls |
 		someX collect: [ :v | cls new interpolate: v; interpolateOut: v ].
 	]
 

--- a/src/Roassal3-Animation/RSBackInterpolator.class.st
+++ b/src/Roassal3-Animation/RSBackInterpolator.class.st
@@ -11,7 +11,7 @@ Symmetric anticipatory easing; scales backIn for t in [0, 0.5] and backOut for t
 "
 Class {
 	#name : #RSBackInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#instVars : [
 		'overshoot'
 	],

--- a/src/Roassal3-Animation/RSBounceInterpolator.class.st
+++ b/src/Roassal3-Animation/RSBounceInterpolator.class.st
@@ -11,7 +11,7 @@ Symmetric bounce easing; scales bounceIn for t in [0, 0.5] and bounceOut for t i
 "
 Class {
 	#name : #RSBounceInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#instVars : [
 		'b1',
 		'b2',

--- a/src/Roassal3-Animation/RSCircleInterpolator.class.st
+++ b/src/Roassal3-Animation/RSCircleInterpolator.class.st
@@ -13,7 +13,7 @@ Symmetric circular easing; scales circleIn for t in {0. 0.5} and circleOut for t
 "
 Class {
 	#name : #RSCircleInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#category : #'Roassal3-Animation-Easing'
 }
 

--- a/src/Roassal3-Animation/RSCubicInterpolator.class.st
+++ b/src/Roassal3-Animation/RSCubicInterpolator.class.st
@@ -13,7 +13,7 @@ Also equivalent to TSEasing poly exponent: 3.
 "
 Class {
 	#name : #RSCubicInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#category : #'Roassal3-Animation-Easing'
 }
 

--- a/src/Roassal3-Animation/RSEasingInterpolator.class.st
+++ b/src/Roassal3-Animation/RSEasingInterpolator.class.st
@@ -4,7 +4,7 @@ Given the specified normalized time t, typically in the range [0,1], returns the
 I am highly inspired from d3js source code https://github.com/d3/d3-transition and from the base animation of Bloc https://github.com/pharo-graphics/Bloc
 "
 Class {
-	#name : #RSEasing,
+	#name : #RSEasingInterpolator,
 	#superclass : #NSInterpolator,
 	#instVars : [
 		'useOut',
@@ -14,229 +14,229 @@ Class {
 }
 
 { #category : #back }
-RSEasing class >> back [
+RSEasingInterpolator class >> back [
 	^ self backInOut
 ]
 
 { #category : #back }
-RSEasing class >> backIn [
+RSEasingInterpolator class >> backIn [
 	^ RSBackInterpolator new in
 ]
 
 { #category : #back }
-RSEasing class >> backInOut [
+RSEasingInterpolator class >> backInOut [
 	^ RSBackInterpolator new
 ]
 
 { #category : #back }
-RSEasing class >> backOut [
+RSEasingInterpolator class >> backOut [
 	^ RSBackInterpolator new out
 ]
 
 { #category : #bounce }
-RSEasing class >> bounce [
+RSEasingInterpolator class >> bounce [
 	^ self bounceOut
 ]
 
 { #category : #bounce }
-RSEasing class >> bounceIn [
+RSEasingInterpolator class >> bounceIn [
 	^ RSBounceInterpolator new in
 ]
 
 { #category : #bounce }
-RSEasing class >> bounceInOut [
+RSEasingInterpolator class >> bounceInOut [
 	^ RSBounceInterpolator new
 ]
 
 { #category : #bounce }
-RSEasing class >> bounceOut [
+RSEasingInterpolator class >> bounceOut [
 	^ RSBounceInterpolator new out
 ]
 
 { #category : #circle }
-RSEasing class >> circle [
+RSEasingInterpolator class >> circle [
 	^ self circleInOut
 ]
 
 { #category : #circle }
-RSEasing class >> circleIn [
+RSEasingInterpolator class >> circleIn [
 	^ RSCircleInterpolator new in
 ]
 
 { #category : #circle }
-RSEasing class >> circleInOut [
+RSEasingInterpolator class >> circleInOut [
 	^ RSCircleInterpolator new
 ]
 
 { #category : #circle }
-RSEasing class >> circleOut [
+RSEasingInterpolator class >> circleOut [
 	^ RSCircleInterpolator new out
 ]
 
 { #category : #cubic }
-RSEasing class >> cubic [
+RSEasingInterpolator class >> cubic [
 	^ self cubicInOut
 ]
 
 { #category : #cubic }
-RSEasing class >> cubicIn [
+RSEasingInterpolator class >> cubicIn [
 	^ RSCubicInterpolator new in
 ]
 
 { #category : #cubic }
-RSEasing class >> cubicInOut [
+RSEasingInterpolator class >> cubicInOut [
 	^ RSCubicInterpolator new
 ]
 
 { #category : #cubic }
-RSEasing class >> cubicOut [
+RSEasingInterpolator class >> cubicOut [
 	^ RSCubicInterpolator new out
 ]
 
 { #category : #elastic }
-RSEasing class >> elastic [
+RSEasingInterpolator class >> elastic [
 	^ self elasticInOut
 ]
 
 { #category : #elastic }
-RSEasing class >> elasticIn [
+RSEasingInterpolator class >> elasticIn [
 	^ RSElasticInterpolator new in
 ]
 
 { #category : #elastic }
-RSEasing class >> elasticInOut [
+RSEasingInterpolator class >> elasticInOut [
 	^ RSElasticInterpolator new
 ]
 
 { #category : #elastic }
-RSEasing class >> elasticOut [
+RSEasingInterpolator class >> elasticOut [
 	^ RSElasticInterpolator new out
 ]
 
 { #category : #exp }
-RSEasing class >> exp [
+RSEasingInterpolator class >> exp [
 	^ self expInOut
 ]
 
 { #category : #exp }
-RSEasing class >> expIn [
+RSEasingInterpolator class >> expIn [
 	^ RSExpInterpolator new in
 ]
 
 { #category : #exp }
-RSEasing class >> expInOut [
+RSEasingInterpolator class >> expInOut [
 	^ RSExpInterpolator new
 ]
 
 { #category : #exp }
-RSEasing class >> expOut [
+RSEasingInterpolator class >> expOut [
 	^ RSExpInterpolator new out
 ]
 
 { #category : #linear }
-RSEasing class >> linear [
+RSEasingInterpolator class >> linear [
 	^ RSLinearInterpolator new
 ]
 
 { #category : #poly }
-RSEasing class >> poly [
+RSEasingInterpolator class >> poly [
 	^ self polyInOut
 ]
 
 { #category : #poly }
-RSEasing class >> polyIn [
+RSEasingInterpolator class >> polyIn [
 	^ RSPolyInterpolator new in
 ]
 
 { #category : #poly }
-RSEasing class >> polyInOut [
+RSEasingInterpolator class >> polyInOut [
 	^ RSPolyInterpolator new.
 ]
 
 { #category : #poly }
-RSEasing class >> polyOut [
+RSEasingInterpolator class >> polyOut [
 	^ RSPolyInterpolator new out
 ]
 
 { #category : #quad }
-RSEasing class >> quad [
+RSEasingInterpolator class >> quad [
 	^ self quadInOut
 ]
 
 { #category : #quad }
-RSEasing class >> quadIn [
+RSEasingInterpolator class >> quadIn [
 	^ RSQuadInterpolator new in
 ]
 
 { #category : #quad }
-RSEasing class >> quadInOut [
+RSEasingInterpolator class >> quadInOut [
 	^ RSQuadInterpolator new
 ]
 
 { #category : #quad }
-RSEasing class >> quadOut [
+RSEasingInterpolator class >> quadOut [
 	^ RSQuadInterpolator new out
 ]
 
 { #category : #sin }
-RSEasing class >> sin [
+RSEasingInterpolator class >> sin [
 	^ self sinInOut
 ]
 
 { #category : #sin }
-RSEasing class >> sinIn [
+RSEasingInterpolator class >> sinIn [
 	^ RSSinInterpolator new in
 ]
 
 { #category : #sin }
-RSEasing class >> sinInOut [
+RSEasingInterpolator class >> sinInOut [
 	^ RSSinInterpolator new
 ]
 
 { #category : #sin }
-RSEasing class >> sinOut [
+RSEasingInterpolator class >> sinOut [
 	^ RSSinInterpolator new out
 ]
 
 { #category : #actions }
-RSEasing >> in [
+RSEasingInterpolator >> in [
 	useIn := true.
 ]
 
 { #category : #actions }
-RSEasing >> inOut [
+RSEasingInterpolator >> inOut [
 	useIn := useOut := false
 ]
 
 { #category : #initialization }
-RSEasing >> initialize [
+RSEasingInterpolator >> initialize [
 	super initialize.
 	self inOut.
 ]
 
 { #category : #interpolation }
-RSEasing >> interpolate: t [
+RSEasingInterpolator >> interpolate: t [
 	useIn ifTrue: [ ^ self interpolateIn: t ].
 	useOut ifTrue: [ ^ self interpolateOut: t ].
 	^ self interpolateInOut: t.
 ]
 
 { #category : #interpolation }
-RSEasing >> interpolateIn: t [
+RSEasingInterpolator >> interpolateIn: t [
 	^ self subclassResponsibility
 ]
 
 { #category : #interpolation }
-RSEasing >> interpolateInOut: t [
+RSEasingInterpolator >> interpolateInOut: t [
 	^ self subclassResponsibility 
 ]
 
 { #category : #interpolation }
-RSEasing >> interpolateOut: t [
+RSEasingInterpolator >> interpolateOut: t [
 	^ self subclassResponsibility
 ]
 
 { #category : #actions }
-RSEasing >> out [ 
+RSEasingInterpolator >> out [ 
 	useOut := true.
 ]

--- a/src/Roassal3-Animation/RSElasticInterpolator.class.st
+++ b/src/Roassal3-Animation/RSElasticInterpolator.class.st
@@ -11,7 +11,7 @@ Symmetric elastic easing; scales elasticIn for t in [0, 0.5] and elasticOut for 
 "
 Class {
 	#name : #RSElasticInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#instVars : [
 		'tau',
 		'amplitude',

--- a/src/Roassal3-Animation/RSExpInterpolator.class.st
+++ b/src/Roassal3-Animation/RSExpInterpolator.class.st
@@ -11,7 +11,7 @@ Symmetric exponential easing; scales expIn for t in [0, 0.5] and expOut for t in
 "
 Class {
 	#name : #RSExpInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#category : #'Roassal3-Animation-Easing'
 }
 

--- a/src/Roassal3-Animation/RSPolyInterpolator.class.st
+++ b/src/Roassal3-Animation/RSPolyInterpolator.class.st
@@ -15,7 +15,7 @@ Symmetric polynomial easing; scales polyIn for t in [0, 0.5] and polyOut for t i
 "
 Class {
 	#name : #RSPolyInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#instVars : [
 		'exponent'
 	],

--- a/src/Roassal3-Animation/RSQuadInterpolator.class.st
+++ b/src/Roassal3-Animation/RSQuadInterpolator.class.st
@@ -12,7 +12,7 @@ Also equivalent to TSEasing poly exponent: 2.
 "
 Class {
 	#name : #RSQuadInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#category : #'Roassal3-Animation-Easing'
 }
 

--- a/src/Roassal3-Animation/RSSinInterpolator.class.st
+++ b/src/Roassal3-Animation/RSSinInterpolator.class.st
@@ -11,7 +11,7 @@ Symmetric sinusoidal easing; scales sinIn for t in [0, 0.5] and sinOut for t in 
 "
 Class {
 	#name : #RSSinInterpolator,
-	#superclass : #RSEasing,
+	#superclass : #RSEasingInterpolator,
 	#category : #'Roassal3-Animation-Easing'
 }
 

--- a/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
@@ -13,7 +13,7 @@ RSBarChartExample >> example01TwoBars [
 	| c p p2 x y size |
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSBarPlot new x: x y: y.
 	size := 6.
 	p barSize: size.
@@ -49,7 +49,7 @@ RSBarChartExample >> example02TwoHorizontalBars [
 	| c p p2 x y size lb |
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSHorizontalBarPlot new x: y y: x.
 	size := 5.
 	p barSize: size.
@@ -61,7 +61,7 @@ RSBarChartExample >> example02TwoHorizontalBars [
 	c addPlot: p2.
 	c build.
 	p bars , p2 bars @ RSPopup.
-	lb := RSLegend new.
+	lb := RSLegendBuilder new.
 	lb container: c canvas.
 	lb text: 'Series1' withBoxColor: p computeColor.
 	lb text: 'Series2' withBoxColor: p2 computeColor.
@@ -108,9 +108,9 @@ RSBarChartExample >> example03TilePaint [
 		paint repeat.
 		paint ].
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 300@ 200.
-	lb := RSLegend new.
+	lb := RSLegendBuilder new.
 	lb container: c canvas.
 	size := 25.
 
@@ -148,7 +148,7 @@ RSBarChartExample >> example03TilePaint [
 RSBarChartExample >> example04VerticalStack [
 	<script: 'self new example04VerticalStack open'>
 	| c menMeans womenMeans lb |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 300@200.
 	menMeans := #(20 35 30 35 27).
 	womenMeans := #(25 32 34 20 25).
@@ -160,7 +160,7 @@ RSBarChartExample >> example04VerticalStack [
 	c ylabel: 'Scores'.
 	c title: 'Scores by group of gender'.
 	c build.
-	lb := RSLegend new.
+	lb := RSLegendBuilder new.
 	lb layout horizontal.
 	#(Men Women) doWithIndex: [ :lbl :index | 
 		lb text: lbl withBoxColor: (c plots at:index) computeColor ].
@@ -173,7 +173,7 @@ RSBarChartExample >> example04VerticalStack [
 RSBarChartExample >> example05HorizontalStack [
 	<script: 'self new example05HorizontalStack open'>
 	| c menMeans womenMeans lb |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 300@200.
 	menMeans := #(20 35 30 35 27).
 	womenMeans := #(25 32 34 20 25).
@@ -185,7 +185,7 @@ RSBarChartExample >> example05HorizontalStack [
 	c xlabel: 'Scores'.
 	c title: 'Scores by group of gender'.
 	c build.
-	lb := RSLegend new.
+	lb := RSLegendBuilder new.
 	lb layout horizontal.
 	#(Men Women) doWithIndex: [ :lbl :index | 
 		lb text: lbl withBoxColor: (c plots at:index) computeColor ].
@@ -213,7 +213,7 @@ RSBarChartExample >> example06BarAnimation [
 			].
 		
 		canvas newAnimation
-			easing: RSEasing circleOut;
+			easing: RSEasingInterpolator circleOut;
 			delay: (index * 200) milliSeconds;
 			duration: 1 second;
 			from: from;
@@ -233,7 +233,7 @@ RSBarChartExample >> example07DoubleBar [
 	<script: 'self new example07DoubleBar open'>
 	| c classes x1 x2 y plot title |
 	
-	c := RSChart new.
+	c := RSChartBuilder new.
 	classes := RSShape withAllSubclasses asOrderedCollection 
 		sorted: [:a :b | a name<b name ].
 	x1 := classes collect: #numberOfMethods.

--- a/src/Roassal3-Chart-Examples/RSBoxPlotExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBoxPlotExample.class.st
@@ -16,7 +16,7 @@ RSBoxPlotExample >> example01 [
 	y := { { 1. 2. 3. 4. 5. } . 
 			 { 5. 6. 7. 5. 10. }  .
 			 { 12. 12. 13. 14. 15. 24. }  }. 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSBoxPlot new y: y.
 	
 	c addPlot: p.
@@ -51,7 +51,7 @@ RSBoxPlotExample >> example02 [
 			 { 12. 7. 10. 11. 11. 13. 10. 11. 12. 11. 15. 16. }  .
 			 { 12. 12. 13. 15. 18. 20. 21. 24. 25. 24. 25. 26. 24. 23. 23. 25. 25. }  }.
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSBoxPlot new y: y.
 	
 	"size controls the width of the bars"

--- a/src/Roassal3-Chart-Examples/RSChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSChartExample.class.st
@@ -12,7 +12,7 @@ RSChartExample >> example01Markers [
 	<script: 'self new example01Markers open'>
 	| x c p |
 	x := -3.14 to: 3.14 by: 0.01.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSLinePlot new.
 	p x: x y: x sin * 0.22 + 0.5.
 	c addPlot: p.
@@ -33,7 +33,7 @@ RSChartExample >> example02ScatterPlot [
 
 	| classes c p |
 	classes := Collection withAllSubclasses.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSScatterPlot new x: (classes collect: #numberOfMethods) y: (classes collect: #linesOfCode).
 	c addPlot: p.
 	
@@ -49,7 +49,7 @@ RSChartExample >> example03Plot [
 
 	| plt p x |
 	x := 0.0 to: 2 count: 100.
-	plt := RSChart new.
+	plt := RSChartBuilder new.
 	p := RSLinePlot new x: x y: (x raisedTo: 2).
 	plt addPlot: p.
 
@@ -70,7 +70,7 @@ RSChartExample >> example04WithTick [
 	<script: 'self new example04WithTick show'>
 	| x |
 	x := -10.0 to: 20.0 count: 100.
-	^ RSChart new
+	^ RSChartBuilder new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
 		addDecoration: RSHorizontalTick new integer;
@@ -83,7 +83,7 @@ RSChartExample >> example05WithTick [
 	<script: 'self new example05WithTick show'>
 	| x c |
 	x := 0.0 to: 14 count: 100.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	1 to: 7 do: [ :i |
 		c addPlot: (RSLinePlot new x: x y: (i * 0.3 + x) sin * (7 - i))
 	].
@@ -97,7 +97,7 @@ RSChartExample >> example06CustomNumberOfTicks [
 	<script: 'self new example06CustomNumberOfTicks show'>
 	| x |
 	x := -10.0 to: 20.0 count: 100.
-	^ RSChart new
+	^ RSChartBuilder new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
 		addDecoration: (RSHorizontalTick new 
@@ -117,7 +117,7 @@ RSChartExample >> example07AdjustingFontSize [
 	x := -3.14 to: 3.14 by: 0.1.
 	y := x sin.
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new x: x y: y).
 	c addDecoration: (RSChartTitleDecoration new title: 'hello'; fontSize: 20).
 	c addDecoration: (RSXLabelDecoration new title: 'My X Axis'; fontSize: 12).
@@ -132,7 +132,7 @@ RSChartExample >> example08TwoCharts [
 	c := RSCanvas new.
 
 	g1 := RSGroup new.
-	c1 := RSChart new.
+	c1 := RSChartBuilder new.
 	c1 container: g1.
 	c1 addPlot: (RSLinePlot new x: (1 to: 10) y: (1 to: 10) sqrt).
 	c1 title: 'squared root'.
@@ -141,7 +141,7 @@ RSChartExample >> example08TwoCharts [
 	c1 build.
 
 	g2 := RSGroup new.
-	c2 := RSChart new.
+	c2 := RSChartBuilder new.
 	c2 container: g2.
 	c2 addPlot: (RSLinePlot new x: (1 to: 10) y: (1 to: 10) squared).
 	c2 title: '^ 2'.
@@ -166,7 +166,7 @@ RSChartExample >> example09LinearSqrtSymlog [
 	#(yLinear ySqrt yLog) do: [ :sel | 
 		| chart g |
 		g := RSGroup new.
-		chart := RSChart new.
+		chart := RSChartBuilder new.
 		chart container: g.
 		chart addPlot: (RSLinePlot new x: x y: y).
 		chart addDecoration: (RSVerticalTick new asFloat).
@@ -185,7 +185,7 @@ RSChartExample >> example10BarPlot [
 
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSBarPlot new x: x y: y.
 
 	c addPlot: p.
@@ -209,7 +209,7 @@ RSChartExample >> example11BarplotCombinedWithLine [
 	| c x y |
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 
 	c addPlot: (RSBarPlot new x: x y: y).
 	c addPlot: (RSLinePlot new x: x y: y; color: Color red).
@@ -237,7 +237,7 @@ RSChartExample >> example12ScatterPlotAndNormalizer [
 		y add: i + (r next * 10 + 1) asInteger.
 		z add: i + (r next * 10 + 1) asInteger. ].
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSScatterPlot new x: x y: y.
 	p color: Color blue translucent.
 
@@ -315,7 +315,7 @@ RSChartExample >> example18Animation [
 		afterline add: (canvas transitionAnimation
 			delay: (index * 300) milliSeconds;
 			duration: 2 second;
-			easing: RSEasing elasticOut;
+			easing: RSEasingInterpolator elasticOut;
 			from: -100@ s position y;
 			to: s position;
 			onStepDo: [:p | 
@@ -330,7 +330,7 @@ RSChartExample >> example19PositiveNetagiveBarPlots [
 	<script: 'self new example19PositiveNetagiveBarPlots open'>
 	| c d d2 |
 	
-	c := RSChart new.
+	c := RSChartBuilder new.
 
 	d := RSBarPlot new.
 	d color: Color green darker darker darker translucent.
@@ -356,7 +356,7 @@ RSChartExample >> example20Grid [
 	<script: 'self new example20Grid open'>
 	| c x y vertical horizontal |
 	
-	c := RSChart new.
+	c := RSChartBuilder new.
 	x := 0 to: 10.
 	y := x raisedTo: 2.
 	c lineX: x y: y.
@@ -379,10 +379,10 @@ RSChartExample >> example21Popup [
 		sum := 0.
 		arr collect: [ :v | sum := sum + v. sum ] ].
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 800@400.
 
-	popup := RSPopupDecoration new.
+	popup := RSChartPopupDecoration new.
 	c addDecoration: popup.
 
 	#(
@@ -453,8 +453,8 @@ RSChartExample >> example22CustomPopup [
 	names := values collect: #key.
 	x := 1 to: values size.
 	y := values collect: #value.
-	popup := RSPopupDecoration new.
-	c := RSChart new.
+	popup := RSChartPopupDecoration new.
+	c := RSChartBuilder new.
 	c extent: 400@ 150.
 	c addPlot: (RSAreaPlot new
 		x: x y1: y y2: 750;
@@ -485,7 +485,7 @@ RSChartExample >> example22CustomPopup [
 RSChartExample >> example23PopupInScatterPlot [
 	<script: 'self new example23PopupInScatterPlot open'>
 	| chart plot data |
-	chart := RSChart new.
+	chart := RSChartBuilder new.
 	data := #(1 2 3).
 	plot := RSScatterPlot new y: data.
 	chart addPlot: plot.

--- a/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
@@ -12,7 +12,7 @@ RSHistogramExample >> example01RandomValues [
 	<script: 'self new example01RandomValues open'>
 	| c p values |
 	values := self randomValues.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSLinePlot new x:(1 to: values size) y: values.
 	c addPlot: p.
 	c addDecoration: (RSHorizontalTick new doNotUseNiceLabel).
@@ -25,7 +25,7 @@ RSHistogramExample >> example02Histogram [
 	<script: 'self new example02Histogram open'>
 	| values c plot |
 	values := self randomValues.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	plot := RSHistogramPlot new x: values.
 	c addPlot: plot.
 	c addDecoration: RSVerticalTick new.
@@ -41,7 +41,7 @@ RSHistogramExample >> example03Bins [
 	canvas := RSCanvas new.
 	shapes := #(3 5 10 20) collect: [ :numberOfBins| | g c plot |
 		g := RSGroup new.
-		c := RSChart new.
+		c := RSChartBuilder new.
 		c container: g.
 		plot := RSHistogramPlot new x: values; bins: numberOfBins.
 		c addPlot: plot.
@@ -70,7 +70,7 @@ RSHistogramExample >> example04BinningStrat [
 		RSSturgesBinning new.
 	 } collect: [ :strat | | g c plot |
 		g := RSGroup new.
-		c := RSChart new.
+		c := RSChartBuilder new.
 		c container: g.
 		plot := RSHistogramPlot new x: values; binningStrategy: strat.
 		c addPlot: plot.
@@ -112,7 +112,7 @@ RSHistogramExample >> example06Animations [
 		shape newAnimation
 			from: zeroPoint;
 			to: originalPoint;
-			easing: RSEasing elasticOut;
+			easing: RSEasingInterpolator elasticOut;
 			onStepDo: [ :newPoint | 
 				shape
 					fromRectangle: (newPoint corner: rect corner);
@@ -148,7 +148,7 @@ RSHistogramExample >> example08Strategies [
 		RSSturgesBinning new.
 	 } collect: [ :strat | | g c plot |
 		g := RSGroup new.
-		c := RSChart new.
+		c := RSChartBuilder new.
 		c container: g.
 		y := x collect: [ :v | strat computeSizeFor: (Array new: v) ].
 		plot := RSLinePlot new x: x y: y.
@@ -170,7 +170,7 @@ RSHistogramExample >> example09BinsCollection [
 	<script: 'self new example09BinsCollection open'>
 	| values c plot |
 	values := self randomValues.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	plot := RSHistogramPlot new x: values.
 	plot bins: #(100 150 155 180 200).
 	c addPlot: plot.

--- a/src/Roassal3-Chart-Examples/RSTimelineExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSTimelineExample.class.st
@@ -19,7 +19,7 @@ RSTimelineExample >> example01Gantt [
 		#(5 10)
 		#(5 8)).
 	names := #(c1 c2 c3 c4 c5).
-	chart := RSChart new.
+	chart := RSChartBuilder new.
 	data doWithIndex: [ :line :index |
 		plot := RSTimeLinePlot new.
 		plot entries: line at: index.
@@ -51,7 +51,7 @@ RSTimelineExample >> example02Labeled [
 		#(5 10)
 		#(5 8)).
 	names := #(c1 c2 c3 c4 c5).
-	chart := RSChart new.
+	chart := RSChartBuilder new.
 	data doWithIndex: [ :line :index |
 		plot := RSTimeLinePlot new.
 		plot entries: line at: index.

--- a/src/Roassal3-Chart-Tests/RSAbstractChartTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSAbstractChartTest.class.st
@@ -20,7 +20,7 @@ RSAbstractChartTest >> classToTest [
 { #category : #running }
 RSAbstractChartTest >> setUp [ 
 	super setUp.
-	chart := RSChart new.
+	chart := RSChartBuilder new.
 	
 ]
 
@@ -44,7 +44,7 @@ RSAbstractChartTest >> testEmptyPlot [
 { #category : #tests }
 RSAbstractChartTest >> testOpening [
 	| x |
-	chart := RSChart new.
+	chart := RSChartBuilder new.
 	x := 0 to: 2 by: 1 / 100.
 	chart addPlot: (self classToTest new x: x y: x).
 	chart addPlot: (self classToTest new x: x y: (x collect: #squared)).

--- a/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
@@ -30,7 +30,7 @@ RSBarPlotTest >> testHorizontalBar [
 	| c p x y |
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSHorizontalBarPlot new x: x y: y.
 	
 	self deny: p isVerticalBarPlot.
@@ -48,7 +48,7 @@ RSBarPlotTest >> testVerticalBar [
 	| c p x y |
 	x := 0.0 to: 2 count: 10.
 	y := (x raisedTo: 2) - 2.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p := RSBarPlot new x: x y: y.
 	
 	self assert: p isVerticalBarPlot.

--- a/src/Roassal3-Chart-Tests/RSChartTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTest.class.st
@@ -10,7 +10,7 @@ RSChartTest >> testBasic [
 	| x |
 	x := -10.0 to: 20.0 count: 100.
 
-	RSChart new
+	RSChartBuilder new
     addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
     addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
 	addDecoration: RSHorizontalTick new;
@@ -23,7 +23,7 @@ RSChartTest >> testMinMaxValue [
 
 	| y c |
 	y := #(10 13 15).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new y: y).
 	c build.
 	self assert: c minValueX equals: 1.
@@ -38,7 +38,7 @@ RSChartTest >> testMinMaxValue2 [
 	| y c x |
 	y := #(-10 -13 -15).
 	x := #(4 6 9).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new x: x y: y).
 	c build.
 	self assert: c minValueX equals: 4.
@@ -52,7 +52,7 @@ RSChartTest >> testMustInclude0 [
 
 	| y c |
 	y := #(10 13 15).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new y: y).
 	c mustInclude0inY.
 	c build.
@@ -67,7 +67,7 @@ RSChartTest >> testMustInclude02 [
 
 	| y c |
 	y := #(-10 -13 -15).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new y: y).
 	c mustInclude0inY.
 	c build.
@@ -83,7 +83,7 @@ RSChartTest >> testMustInclude03 [
 	| y c x |
 	y := #(-10 -13 -15).
 	x := #(4 6 9).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addPlot: (RSLinePlot new x: x y: y).
 	c mustInclude0inX.
 	c build.
@@ -98,7 +98,7 @@ RSChartTest >> testWithWeirdValues [
 
 	| values g d line c |
 	values := {Float infinity negated. Float infinity negated. 0.30102999566398114. 0.47712125471966244}.
-	g := RSChart new.
+	g := RSChartBuilder new.
 	d := RSLinePlot new y: values.
 	g addPlot: d.
 	g build.
@@ -116,7 +116,7 @@ RSChartTest >> testWithWeirdValuesLine [
 
 	| values g d line c |
 	values := {Float infinity negated. Float infinity negated. 0.30102999566398114. 0.47712125471966244}.
-	g := RSChart new.
+	g := RSChartBuilder new.
 	d := RSLinePlot new y: values.
 	g addPlot: d.
 	g build.
@@ -134,7 +134,7 @@ RSChartTest >> testWithWeirdValuesLineWithTicks [
 
 	| values g d line c |
 	values := {Float infinity negated. Float infinity negated. 0.30102999566398114. 0.47712125471966244}.
-	g := RSChart new.
+	g := RSChartBuilder new.
 	d := RSLinePlot new y: values.
 	g addPlot: d.
 	g addDecoration: RSHorizontalTick new.
@@ -153,7 +153,7 @@ RSChartTest >> testWithWeirdValuesLineWithTicks [
 RSChartTest >> testWithWeirdValuesLineWithTicks2 [
 	| x g d c labels |
 	x := { -5 . 0 . 1 . 2 }.
-	g := RSChart new.
+	g := RSChartBuilder new.
 	d := RSLinePlot new x: x y: x log.
 	g addPlot: d.
 	g addDecoration: RSVerticalTick new.
@@ -177,7 +177,7 @@ RSChartTest >> testYMarker [
 
 	| x c p1 p2 marker line |
 	x := -3.14 to: 3.14 by: 0.01.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	p1 := RSLinePlot new.
 	p1 x: x y: x sin * 0.22.
 	c addPlot: p1.

--- a/src/Roassal3-Chart-Tests/RSChartTickTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTickTest.class.st
@@ -9,7 +9,7 @@ RSChartTickTest >> testDoNotUseNiceLabel [
 	| x c numberOfTicks vertical |
 	x := -10.0 to: 20.0 count: 100.
 	numberOfTicks := 2.
-	c := RSChart new
+	c := RSChartBuilder new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
 		addDecoration: (RSHorizontalTick new 
@@ -37,7 +37,7 @@ RSChartTickTest >> testFromNames [
 			dates add: d.
 			y add: f ].
 	x := 1 to: dates size.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 300@200.
 	
 	c addPlot: (RSLinePlot new x: x y: y).

--- a/src/Roassal3-Chart-Tests/RSChartTitleDecorationTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTitleDecorationTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 RSChartTitleDecorationTest >> testBasic [
 	| c title label |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	title := c title: 'hello'.
 	title baseShape
 		color: Color blue.
@@ -23,7 +23,7 @@ RSChartTitleDecorationTest >> testBasic [
 { #category : #tests }
 RSChartTitleDecorationTest >> testBasic2 [
 	| c |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c addDecoration: (RSChartTitleDecoration new title: 'hello'; fontSize: 20).
 	c build.
 	 

--- a/src/Roassal3-Chart-Tests/RSHistogramPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSHistogramPlotTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 RSHistogramPlotTest >> testBasic [
 	| c values plot |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values).
 	c build.
@@ -20,7 +20,7 @@ RSHistogramPlotTest >> testBasic [
 { #category : #tests }
 RSHistogramPlotTest >> testBins [
 	| c values plot |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values; bins: 2).
 	c build.
@@ -33,7 +33,7 @@ RSHistogramPlotTest >> testBins [
 { #category : #tests }
 RSHistogramPlotTest >> testBinsCollection [
 	| c values plot |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values; bins: #(1 5 8 10)).
 	c build.
@@ -46,7 +46,7 @@ RSHistogramPlotTest >> testBinsCollection [
 { #category : #tests }
 RSHistogramPlotTest >> testBinsStrat [
 	| c values plot |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	values := (1 to: 100) shuffled.
 	c addPlot: (plot := RSHistogramPlot new x: values; binningStrategy: RSSturgesBinning new).
 	c build.

--- a/src/Roassal3-Chart/RSAbstractChartPlot.class.st
+++ b/src/Roassal3-Chart/RSAbstractChartPlot.class.st
@@ -2,7 +2,7 @@
 TODO
 "
 Class {
-	#name : #RSAbstractChartElement,
+	#name : #RSAbstractChartPlot,
 	#superclass : #Object,
 	#instVars : [
 		'chart',
@@ -13,28 +13,28 @@ Class {
 }
 
 { #category : #rendering }
-RSAbstractChartElement >> addShape: aShape [
+RSAbstractChartPlot >> addShape: aShape [
 	"Add a shape to the canvas"
 	chart canvas add: aShape
 ]
 
 { #category : #rendering }
-RSAbstractChartElement >> beforeRenderingIn: aChart [
+RSAbstractChartPlot >> beforeRenderingIn: aChart [
 	"do nothing here"
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> chart [
+RSAbstractChartPlot >> chart [
 	^ chart
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> chart: aChart [
+RSAbstractChartPlot >> chart: aChart [
 	chart := aChart
 ]
 
 { #category : #rendering }
-RSAbstractChartElement >> createXScale [
+RSAbstractChartPlot >> createXScale [
 	| padding |
 	xScale ifNil: [ xScale := NSScale linear ].
 	xScale class = NSOrdinalScale ifTrue: [ ^ self ].
@@ -49,7 +49,7 @@ RSAbstractChartElement >> createXScale [
 ]
 
 { #category : #rendering }
-RSAbstractChartElement >> createYScale [
+RSAbstractChartPlot >> createYScale [
 	| padding |
 	yScale ifNil: [ yScale := NSScale linear ].
 	yScale class = NSOrdinalScale ifTrue: [ ^ self ].
@@ -65,13 +65,13 @@ RSAbstractChartElement >> createYScale [
 ]
 
 { #category : #rendering }
-RSAbstractChartElement >> renderIn: canvas [
+RSAbstractChartPlot >> renderIn: canvas [
 	"Need to be overridden in subclasses. This methods has to be use trachel to enrich a visualization"
 	self subclassResponsibility
 ]
 
 { #category : #rendering }
-RSAbstractChartElement >> spine [
+RSAbstractChartPlot >> spine [
 	"Return the Trachel shape that describe the spine"
 	^ (chart decorations
 		detect: [ :d | d class == RSChartSpineDecoration ]
@@ -80,21 +80,21 @@ RSAbstractChartElement >> spine [
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> xScale [
+RSAbstractChartPlot >> xScale [
 	^ xScale
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> xScale: aScale [
+RSAbstractChartPlot >> xScale: aScale [
 	xScale := aScale
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> yScale [
+RSAbstractChartPlot >> yScale [
 	^ yScale
 ]
 
 { #category : #accessing }
-RSAbstractChartElement >> yScale: aScale [
+RSAbstractChartPlot >> yScale: aScale [
 	yScale := aScale
 ]

--- a/src/Roassal3-Chart/RSAbstractPlot.class.st
+++ b/src/Roassal3-Chart/RSAbstractPlot.class.st
@@ -3,7 +3,7 @@ TODO
 "
 Class {
 	#name : #RSAbstractPlot,
-	#superclass : #RSAbstractChartElement,
+	#superclass : #RSAbstractChartPlot,
 	#instVars : [
 		'xValues',
 		'yValues',

--- a/src/Roassal3-Chart/RSChartBuilder.class.st
+++ b/src/Roassal3-Chart/RSChartBuilder.class.st
@@ -29,7 +29,7 @@ c
 ```
 "
 Class {
-	#name : #RSChart,
+	#name : #RSChartBuilder,
 	#superclass : #RSAbstractContainerBuilder,
 	#instVars : [
 		'plots',
@@ -42,7 +42,7 @@ Class {
 }
 
 { #category : #adding }
-RSChart >> addDecoration: aDecoration [
+RSChartBuilder >> addDecoration: aDecoration [
 	"Add a decoration to the chart
 
 For example:
@@ -61,7 +61,7 @@ c
 ]
 
 { #category : #adding }
-RSChart >> addPlot: aPlot [
+RSChartBuilder >> addPlot: aPlot [
 	"Add a plot to the chart.
 	
 For example:
@@ -78,7 +78,7 @@ c
 ]
 
 { #category : #'public - plots' }
-RSChart >> barHeights: aCollectionY [
+RSChartBuilder >> barHeights: aCollectionY [
 	| res |
 	self addPlot: (res := RSBarPlot new 
 		x: (1 to: aCollectionY size) 
@@ -87,7 +87,7 @@ RSChart >> barHeights: aCollectionY [
 ]
 
 { #category : #'public - plots' }
-RSChart >> barWidths: aCollectionX [
+RSChartBuilder >> barWidths: aCollectionX [
 	| res |
 	self addPlot: (res := RSHorizontalBarPlot new 
 		x: aCollectionX
@@ -96,61 +96,61 @@ RSChart >> barWidths: aCollectionX [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> chartExtents [
+RSChartBuilder >> chartExtents [
 	^ extents ifNil: [ extents := RSChartExtents new ]
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> chartExtents: aRSChartExtents [
+RSChartBuilder >> chartExtents: aRSChartExtents [
 	extents := aRSChartExtents
 ]
 
 { #category : #color }
-RSChart >> colorFor: aRSPlot [ 
+RSChartBuilder >> colorFor: aRSPlot [ 
 	"Return a color for the given plot. Colors are defined as in #defaultPlotColors"
 	^ colors scale: aRSPlot
 ]
 
 { #category : #accessing }
-RSChart >> colors [
+RSChartBuilder >> colors [
 	"Return the palette"
 	^ colors
 ]
 
 { #category : #accessing }
-RSChart >> colors: someColors [
+RSChartBuilder >> colors: someColors [
 	"Set the palette to be use to plots"
 	colors := someColors
 ]
 
 { #category : #accessing }
-RSChart >> decorations [
+RSChartBuilder >> decorations [
 	"Return the list of decorations used to annotate plots"
 	^ decorations
 ]
 
 { #category : #defaults }
-RSChart >> defaultContainer [
+RSChartBuilder >> defaultContainer [
 	^ RSCanvas new @ RSCanvasController
 ]
 
 { #category : #color }
-RSChart >> defaultPlotColors [
+RSChartBuilder >> defaultPlotColors [
 	^ NSScale category20
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> extent [
+RSChartBuilder >> extent [
 	^ self chartExtents extent
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> extent: aPoint [
+RSChartBuilder >> extent: aPoint [
 	self chartExtents extent: aPoint
 ]
 
 { #category : #visualization }
-RSChart >> gtInspectorViewIn: composite [
+RSChartBuilder >> gtInspectorViewIn: composite [
 	<gtInspectorPresentationOrder: -10>
 	composite roassal3
 		title: ['Canvas'];
@@ -159,7 +159,7 @@ RSChart >> gtInspectorViewIn: composite [
 ]
 
 { #category : #initialization }
-RSChart >> initialize [
+RSChartBuilder >> initialize [
 	super initialize.
 	plots := OrderedCollection new.
 	self extent: 200 @ 200.
@@ -168,13 +168,13 @@ RSChart >> initialize [
 ]
 
 { #category : #initialization }
-RSChart >> initializeDecorations [
+RSChartBuilder >> initializeDecorations [
 	decorations := OrderedCollection new.
 	self addDecoration: RSChartSpineDecoration new.
 ]
 
 { #category : #inspector }
-RSChart >> inspectorCanvas [
+RSChartBuilder >> inspectorCanvas [
 	<inspectorPresentationOrder: 90 title: 'Canvas'>
 	self build. 
 	^ SpRoassal3InspectorPresenter new
@@ -183,20 +183,20 @@ RSChart >> inspectorCanvas [
 ]
 
 { #category : #inspector }
-RSChart >> inspectorCanvasContext: aContext [
+RSChartBuilder >> inspectorCanvasContext: aContext [
   
   aContext withoutEvaluator
 ]
 
 { #category : #'public - plots' }
-RSChart >> lineX: aCollectionX y: aCollectionY [
+RSChartBuilder >> lineX: aCollectionX y: aCollectionY [
 	| res |
 	self addPlot: (res := RSLinePlot new x: aCollectionX y: aCollectionY).
 	^ res
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> maxValueX [
+RSChartBuilder >> maxValueX [
 	^ self chartExtents maxValueX
 		ifNil: [ | res |
 			self chartExtents maxValueX: (res := (plots collect: #maxValueX) max).
@@ -205,12 +205,12 @@ RSChart >> maxValueX [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> maxValueX: aNumber [
+RSChartBuilder >> maxValueX: aNumber [
 	self chartExtents maxValueX: aNumber
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> maxValueY [
+RSChartBuilder >> maxValueY [
 	^ self chartExtents maxValueY
 		ifNil: [ | res |
 			self chartExtents maxValueY: (res := (plots collect: #maxValueY) max).
@@ -220,12 +220,12 @@ RSChart >> maxValueY [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> maxValueY: aNumber [
+RSChartBuilder >> maxValueY: aNumber [
 	self chartExtents maxValueY: aNumber
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> minValueX [ 
+RSChartBuilder >> minValueX [ 
 	^ self chartExtents minValueX
 		ifNil: [ | res |
 			self chartExtents minValueX: (res := (plots collect: #minValueX) min).
@@ -234,12 +234,12 @@ RSChart >> minValueX [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> minValueX: aNumber [
+RSChartBuilder >> minValueX: aNumber [
 	self chartExtents minValueX: aNumber
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> minValueY [
+RSChartBuilder >> minValueY [
 	^ self chartExtents minValueY
 		ifNil: [ | res |
 			self chartExtents minValueY: (res := (plots collect: #minValueY) min).
@@ -248,12 +248,12 @@ RSChart >> minValueY [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> minValueY: aNumber [
+RSChartBuilder >> minValueY: aNumber [
 	self chartExtents minValueY: aNumber
 ]
 
 { #category : #'public - configuration' }
-RSChart >> mustInclude0inX [
+RSChartBuilder >> mustInclude0inX [
 	"Make sure that the 0 value is in the chart"
 	((self minValueX to: self maxValueX) includes: 0) ifTrue: [ ^ self ].
 	
@@ -263,7 +263,7 @@ RSChart >> mustInclude0inX [
 ]
 
 { #category : #'public - configuration' }
-RSChart >> mustInclude0inY [
+RSChartBuilder >> mustInclude0inY [
 	"Make sure that the 0 value is in the chart"
 	((self minValueY to: self maxValueY) includes: 0) ifTrue: [ ^ self ].
 	
@@ -273,7 +273,7 @@ RSChart >> mustInclude0inY [
 ]
 
 { #category : #accessing }
-RSChart >> niceGenerator [
+RSChartBuilder >> niceGenerator [
 	"Produce a generator for nice labels. Whether nice labels are used or not is a choice made by the horizontal or vertical ticks."
 	^ generator ifNil: [ 
 		generator := RSLabelGenerator new.
@@ -282,19 +282,19 @@ RSChart >> niceGenerator [
 ]
 
 { #category : #accessing }
-RSChart >> numberOfPlots [
+RSChartBuilder >> numberOfPlots [
 	"Return the number of plots contained in the chart"
 	^ plots size
 ]
 
 { #category : #public }
-RSChart >> openOnce [
+RSChartBuilder >> openOnce [
 	self build.
 	^ self canvas openOnce
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> padding [
+RSChartBuilder >> padding [
 	^ self chartExtents padding
 		ifNil: [ | res |
 			self chartExtents padding: (res := 0@0).
@@ -303,40 +303,40 @@ RSChart >> padding [
 ]
 
 { #category : #'accessing - extension' }
-RSChart >> padding: aPoint [
+RSChartBuilder >> padding: aPoint [
 	self chartExtents padding: aPoint asPoint
 ]
 
 { #category : #accessing }
-RSChart >> plots [
+RSChartBuilder >> plots [
 	^ plots
 ]
 
 { #category : #building }
-RSChart >> renderDecorationIn: aCanvas [
+RSChartBuilder >> renderDecorationIn: aCanvas [
 	decorations do: [ :d | d renderIn: aCanvas ]
 ]
 
 { #category : #hooks }
-RSChart >> renderIn: aCanvas [
+RSChartBuilder >> renderIn: aCanvas [
 	decorations, plots do: [ :e | e beforeRenderingIn: self ].
 	self renderDecorationIn: aCanvas.
 	self renderPlotsIn: aCanvas
 ]
 
 { #category : #building }
-RSChart >> renderPlotsIn: aCanvas [
+RSChartBuilder >> renderPlotsIn: aCanvas [
 	plots do: [ :p | p renderIn: aCanvas ].
 	
 ]
 
 { #category : #building }
-RSChart >> show [
+RSChartBuilder >> show [
 	^ self open
 ]
 
 { #category : #accessing }
-RSChart >> title: aTitle [
+RSChartBuilder >> title: aTitle [
 	"Set the title of a chart. For example:
 	
 ```Smalltalk
@@ -350,100 +350,100 @@ c
 ]
 
 { #category : #'public - scales' }
-RSChart >> xLinear [
+RSChartBuilder >> xLinear [
 	^ self xScale: NSScale linear
 ]
 
 { #category : #'public - scales' }
-RSChart >> xLn [
+RSChartBuilder >> xLn [
 	^ self xScale: NSScale ln
 ]
 
 { #category : #'public - scales' }
-RSChart >> xLog [
+RSChartBuilder >> xLog [
 	^ self xScale: NSScale symlog
 ]
 
 { #category : #'public - scales' }
-RSChart >> xRawLog [
+RSChartBuilder >> xRawLog [
 	self xScale: NSScale log
 ]
 
 { #category : #'public - scales' }
-RSChart >> xScale: aScale [
+RSChartBuilder >> xScale: aScale [
 	plots, decorations do: [ :e | e xScale: aScale ].
 	^ aScale
 ]
 
 { #category : #'public - scales' }
-RSChart >> xSqrt [
+RSChartBuilder >> xSqrt [
 	^ self xScale: NSScale sqrt
 ]
 
 { #category : #decoration }
-RSChart >> xlabel: aTitle [
+RSChartBuilder >> xlabel: aTitle [
 	"Set a label on the horizontal axis"
 	^ self addDecoration: (RSXLabelDecoration new title: aTitle)
 ]
 
 { #category : #decoration }
-RSChart >> xlabel: aTitle offset: aPointOrANumber [
+RSChartBuilder >> xlabel: aTitle offset: aPointOrANumber [
 	"Set a label on the horizontal axis, using an offset (useful to avoid overlap with axis labels)"
 	^ self addDecoration: (RSXLabelDecoration new title: aTitle; offset: aPointOrANumber)
 ]
 
 { #category : #decoration }
-RSChart >> xlabelTop: aTitle [
+RSChartBuilder >> xlabelTop: aTitle [
 	"Set a label on the horizontal top axis"
 	^ self addDecoration: (RSXLabelDecoration new title: aTitle; above).
 ]
 
 { #category : #'public - scales' }
-RSChart >> yLinear [
+RSChartBuilder >> yLinear [
 	^ self yScale: NSScale linear
 ]
 
 { #category : #'public - scales' }
-RSChart >> yLn [
+RSChartBuilder >> yLn [
 	^ self yScale: NSScale ln
 ]
 
 { #category : #'public - scales' }
-RSChart >> yLog [
+RSChartBuilder >> yLog [
 	^ self yScale: NSScale symlog
 ]
 
 { #category : #'public - scales' }
-RSChart >> yRawLog [
+RSChartBuilder >> yRawLog [
 	"ensure all your data and axis do not contains zero"
 	^ self yScale: NSScale log
 ]
 
 { #category : #'public - scales' }
-RSChart >> yScale: aScale [
+RSChartBuilder >> yScale: aScale [
 	plots, decorations do: [ :e | e yScale: aScale ].
 	^ aScale
 ]
 
 { #category : #'public - scales' }
-RSChart >> ySqrt [
+RSChartBuilder >> ySqrt [
 	^ self yScale: NSScale sqrt
 ]
 
 { #category : #decoration }
-RSChart >> ylabel: aTitle [
+RSChartBuilder >> ylabel: aTitle [
 	"Set a label on the vertical axis"
 	^ self addDecoration: (RSYLabelDecoration new title: aTitle)
 ]
 
 { #category : #decoration }
-RSChart >> ylabel: aTitle offset: aPointOrANumber [
+RSChartBuilder >> ylabel: aTitle offset: aPointOrANumber [
 	"Set a label on the vertical axis, using an offset (useful to avoid overlap with axis labels)"
 	^ self addDecoration: (RSYLabelDecoration new title: aTitle ; offset: aPointOrANumber)
 ]
 
 { #category : #decoration }
-RSChart >> ylabelRight: aTitle [
+RSChartBuilder >> ylabelRight: aTitle [
 	"Set a label on the vertical axis"
 	^ self addDecoration: (RSYLabelDecoration new title: aTitle; right; yourself)
 ]

--- a/src/Roassal3-Chart/RSChartDecoration.class.st
+++ b/src/Roassal3-Chart/RSChartDecoration.class.st
@@ -3,7 +3,7 @@ TODO
 "
 Class {
 	#name : #RSChartDecoration,
-	#superclass : #RSAbstractChartElement,
+	#superclass : #RSAbstractChartPlot,
 	#category : #'Roassal3-Chart-Decoration'
 }
 

--- a/src/Roassal3-Chart/RSChartPopupDecoration.class.st
+++ b/src/Roassal3-Chart/RSChartPopupDecoration.class.st
@@ -2,7 +2,7 @@
 I am a popup decoration for instances of line Plots in RSChart by default but you can customize this popup decoration with differents shapebuilders, or popups
 "
 Class {
-	#name : #RSPopupDecoration,
+	#name : #RSChartPopupDecoration,
 	#superclass : #RSChartDecoration,
 	#instVars : [
 		'popup'
@@ -11,17 +11,17 @@ Class {
 }
 
 { #category : #accessing }
-RSPopupDecoration >> chartPopupBuilder [
+RSChartPopupDecoration >> chartPopupBuilder [
 	^ self popup chartPopupBuilder
 ]
 
 { #category : #accessing }
-RSPopupDecoration >> chartPopupBuilder: aRSAbstractChartPopupBuilder [
+RSChartPopupDecoration >> chartPopupBuilder: aRSAbstractChartPopupBuilder [
 	self popup chartPopupBuilder: aRSAbstractChartPopupBuilder
 ]
 
 { #category : #initialization }
-RSPopupDecoration >> initialize [
+RSChartPopupDecoration >> initialize [
 	super initialize.
 	popup := RSPopupChart new
 		chartPopupBuilder: RSSimpleChartPopupBuilder new;
@@ -30,17 +30,17 @@ RSPopupDecoration >> initialize [
 ]
 
 { #category : #accessing }
-RSPopupDecoration >> popup [
+RSChartPopupDecoration >> popup [
 	^ popup
 ]
 
 { #category : #accessing }
-RSPopupDecoration >> popup: aRSPopup [
+RSChartPopupDecoration >> popup: aRSPopup [
 	popup := aRSPopup
 ]
 
 { #category : #rendering }
-RSPopupDecoration >> renderIn: canvas [
+RSChartPopupDecoration >> renderIn: canvas [
 	| box |
 	box := chart decorations first shape.
 	popup chart: chart.

--- a/src/Roassal3-Chart/SequenceableCollection.extension.st
+++ b/src/Roassal3-Chart/SequenceableCollection.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #SequenceableCollection }
 { #category : #'*Roassal3-Chart' }
 SequenceableCollection >> rsHistogram [
 	| c plot |
-	c := RSChart new.
+	c := RSChartBuilder new.
 	plot := RSHistogramPlot new x: self.
 	c addPlot: plot.
 	c addDecoration: RSVerticalTick new.

--- a/src/Roassal3-Examples/RSAnimationExamples.class.st
+++ b/src/Roassal3-Examples/RSAnimationExamples.class.st
@@ -207,7 +207,7 @@ RSAnimationExamples >> example05ElasticEllipses [
 				shape color: (color scale: (shape position distanceTo: 0@0)/250 ) ].
 		].
 		canvas newAnimation
-			easing: RSEasing elasticOut;
+			easing: RSEasingInterpolator elasticOut;
 			onStepDo: [ :t |
 				canvas nodes do: [ :shape | | scale |
 					scale := NSScale linear range: { 1. shape propertyAt: #radius }.
@@ -362,7 +362,7 @@ RSAnimationExamples >> example08ArcTree [
 		shapes := canvas nodes select: [ :e | e index = i ].
 		canvas transitionAnimation 
 			duration: 1 seconds;
-			easing: RSEasing bounceOut;
+			easing: RSEasingInterpolator bounceOut;
 			onStepDo: [ :t |
 			shapes do: [ :e |
 				e 
@@ -1760,7 +1760,7 @@ RSAnimationExamples >> example29Tick [
 	(c nodes at: 3) remove.
 	animation := [:a :b :k | c transitionAnimation 
 		duration: 700 milliSeconds;
-		easing: RSEasing bounceOut;
+		easing: RSEasingInterpolator bounceOut;
 		from: a;
 		to: b;
 		onStepDo: [ :t | | s |
@@ -2094,7 +2094,7 @@ RSAnimationExamples >> example35Roassal [
 		color: Color white;
 		fontSize: 30).
 		canvas newAnimation
-			easing: RSEasing elasticOut;
+			easing: RSEasingInterpolator elasticOut;
 			from: -1; to: 0; onStepDo: [ :t |
 			canvas shapes last matrix shy: t ] ]. 
 	canvas when: RSExtentChangedEvent do: [ canvas camera zoomToFit: canvas extent * 0.8 extent: 300@300 ].

--- a/src/Roassal3-Examples/RSBasicAnimationExamples.class.st
+++ b/src/Roassal3-Examples/RSBasicAnimationExamples.class.st
@@ -18,7 +18,7 @@ RSBasicAnimationExamples >> example01Basic [
 	c addShape: b.
 	
 	c newAnimation 
-		easing: RSEasing bounce;
+		easing: RSEasingInterpolator bounce;
 		from: -100@ -100;
 		to: 100@100;
 		on: b set: #position:.

--- a/src/Roassal3-Examples/RSHighlightableExamples.class.st
+++ b/src/Roassal3-Examples/RSHighlightableExamples.class.st
@@ -166,7 +166,7 @@ RSHighlightableExamples >> example06IterateNext [
 	<script: 'self new example06IterateNext open'>
 	| canvas numbers edges layout legendBuilder highlightableForBoxes highlightableForLabels selectedNumber highlightBlock unhighlightAllBlock |
 	canvas := RSCanvas new.
-	legendBuilder := RSLegend new container: canvas. 
+	legendBuilder := RSLegendBuilder new container: canvas. 
 
 	"Create the view with numbers as elements."
 	numbers := (1 to: 10) collect: [ :i |

--- a/src/Roassal3-Examples/RSInspectableExample.class.st
+++ b/src/Roassal3-Examples/RSInspectableExample.class.st
@@ -60,7 +60,7 @@ RSInspectableExample >> example02Inspect [
 	animation := nil.
 	animation := canvas animationFrom: { 
 		canvas transitionAnimation repeat
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		onStepDo: [ :t |
 			canvas nodes do: [ :shape |
 				| att a b |
@@ -98,7 +98,7 @@ RSInspectableExample >> example02Inspect [
 { #category : #examples }
 RSInspectableExample >> example03Easing [
 	<script: 'self new example03Easing inspect'>
-	^ RSEasing bounceOut
+	^ RSEasingInterpolator bounceOut
 ]
 
 { #category : #examples }

--- a/src/Roassal3-Examples/RSLayoutExamples.class.st
+++ b/src/Roassal3-Examples/RSLayoutExamples.class.st
@@ -619,7 +619,7 @@ RSLayoutExamples >> example20FlowLayout [
 RSLayoutExamples >> example21Spaces [
 	<script: 'self new example21Spaces open'>
 	| b prop r |
-	b := RSForceLayoutInSpaces new.
+	b := RSForceLayoutInSpacesBuilder new.
 	b numberOfSpaces: 4.
 	b classes: Collection withAllSubclasses.
 	b build.

--- a/src/Roassal3-Experimental/RSSankeyExamples.class.st
+++ b/src/Roassal3-Experimental/RSSankeyExamples.class.st
@@ -94,7 +94,7 @@ RSSankeyExamples >> example05Animation [
 	b canvas newAnimation
 		repeat;
 		duration: 3 seconds;
-		easing: RSEasing circleOut;
+		easing: RSEasingInterpolator circleOut;
 		onStepDo: [ :t | 
 			b lines do: [ :line | 
 				| paint |

--- a/src/Roassal3-Interaction/RSAnimatedPopup.class.st
+++ b/src/Roassal3-Interaction/RSAnimatedPopup.class.st
@@ -39,7 +39,7 @@ RSAnimatedPopup >> translatePopup: popup event: evt [
 	evt shape newAnimation 
 		duration: 300 milliSeconds; 
 		from: 0.05; to: 1;
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		onStepDo: [ :t | 
 			popup matrix 
 				loadIdentity;

--- a/src/Roassal3-Interaction/RSCanvasController.class.st
+++ b/src/Roassal3-Interaction/RSCanvasController.class.st
@@ -83,7 +83,7 @@ RSCanvasController >> onShape: aCanvas [
 RSCanvasController >> renderLegendOn: aCanvas [
 	| lb |
 	self shouldShowLegend ifFalse: [ ^ self ].
-	lb := RSLegend new 
+	lb := RSLegendBuilder new 
 		container: aCanvas;
 		yourself.
 	lb defaultTitle fontSize: 12.

--- a/src/Roassal3-Interaction/RSDraggableCanvasInteraction.class.st
+++ b/src/Roassal3-Interaction/RSDraggableCanvasInteraction.class.st
@@ -51,7 +51,7 @@ RSDraggableCanvasInteraction >> checkCamera: aCanvas [
 	self removeRectanglesFor: aCanvas.
 	
 	aCanvas newAnimation
-		easing: RSEasing cubicIn;
+		easing: RSEasingInterpolator cubicIn;
 		duration: 200 milliSeconds;
 		from: p;
 		to: correct;
@@ -96,7 +96,7 @@ RSDraggableCanvasInteraction >> mouseEnd: evt [
 	p := p x sqrt @ p y sqrt.
 	
 	aCanvas newAnimation 
-		easing: RSEasing cubicOut;
+		easing: RSEasingInterpolator cubicOut;
 		duration: 200 milliSeconds;
 		from: camera position; to: camera position + (delta / p);
 		on: camera set: #translateTo:;

--- a/src/Roassal3-Interaction/RSKeyNavigationCanvasInteraction.class.st
+++ b/src/Roassal3-Interaction/RSKeyNavigationCanvasInteraction.class.st
@@ -116,7 +116,7 @@ RSKeyNavigationCanvasInteraction >> zoomMove: aCanvas delta: delta [
 	scale := camera scale.
 	newScale := self scaleFor: delta * scale. 
 	aCanvas newAnimation 
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		duration: 200 milliSeconds;
 		from: scale;
 		to: newScale;
@@ -126,7 +126,7 @@ RSKeyNavigationCanvasInteraction >> zoomMove: aCanvas delta: delta [
 		scale: newScale.
 	correct = camera position ifTrue: [ ^ self ].
 	aCanvas newAnimation 
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		duration: 200 milliSeconds;
 		from: camera position;
 		to: correct;

--- a/src/Roassal3-Interaction/RSZoomToFitCanvas.class.st
+++ b/src/Roassal3-Interaction/RSZoomToFitCanvas.class.st
@@ -25,7 +25,7 @@ RSZoomToFitCanvas >> animatedZoomToFit: aCanvas [
 	sc < 1 ifTrue: [ 
 		aCanvas newAnimation
 			duration: 500 milliSeconds;
-			easing: RSEasing backOut;
+			easing: RSEasingInterpolator backOut;
 			onStepDo: [ :t | 
 				camera
 					position: (position scale: t);
@@ -35,13 +35,13 @@ RSZoomToFitCanvas >> animatedZoomToFit: aCanvas [
 	aCanvas newAnimation 
 		delay: 150 milliSeconds;
 		duration: 700 milliSeconds;
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		onStepDo: [:t |
 			camera position: (position scale: t).
 			aCanvas signalUpdate].
 	aCanvas newAnimation
 		duration: 300 milliSeconds;
-		easing: RSEasing exp;
+		easing: RSEasingInterpolator exp;
 		onStepDo: [ :t | 
 				camera scale: (scale scale: t).
 				aCanvas signalUpdate ]

--- a/src/Roassal3-Layouts/RSForceLayoutInSpacesBuilder.class.st
+++ b/src/Roassal3-Layouts/RSForceLayoutInSpacesBuilder.class.st
@@ -2,7 +2,7 @@
 TODO
 "
 Class {
-	#name : #RSForceLayoutInSpaces,
+	#name : #RSForceLayoutInSpacesBuilder,
 	#superclass : #RSAbstractContainerBuilder,
 	#instVars : [
 		'numberOfSpaces',
@@ -17,7 +17,7 @@ Class {
 }
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> abandonLayout: shape [
+RSForceLayoutInSpacesBuilder >> abandonLayout: shape [
 	| layout |
 	layout := shape propertyAt: #layout.
 	shape connectedLines do: [ :ed | layout removeEdge: ed ].
@@ -26,7 +26,7 @@ RSForceLayoutInSpaces >> abandonLayout: shape [
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> addEdgesOf: shape to: space [
+RSForceLayoutInSpacesBuilder >> addEdgesOf: shape to: space [
 	| layout edgesToAdd |
 	layout := space propertyAt: #layout.
 	edgesToAdd := shape connectedLines groupedBy: [ :ed | 
@@ -46,7 +46,7 @@ RSForceLayoutInSpaces >> addEdgesOf: shape to: space [
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> addShape: shape to: space [
+RSForceLayoutInSpacesBuilder >> addShape: shape to: space [
 	| layout |
 	layout := space propertyAt: #layout.
 	layout addNodes: { shape }.
@@ -57,12 +57,12 @@ RSForceLayoutInSpaces >> addShape: shape to: space [
 ]
 
 { #category : #accessing }
-RSForceLayoutInSpaces >> classes: aCollection [ 
+RSForceLayoutInSpacesBuilder >> classes: aCollection [ 
 	classes := aCollection
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> dragEnd: evt [
+RSForceLayoutInSpacesBuilder >> dragEnd: evt [
 	| dropPosition droppedShape targetLayout layout shapesToMove |
 	droppedShape := evt shape.
 	dropPosition := droppedShape position.
@@ -85,7 +85,7 @@ RSForceLayoutInSpaces >> dragEnd: evt [
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> fill: space with: aCollection [
+RSForceLayoutInSpacesBuilder >> fill: space with: aCollection [
 	| layout cpController |
 	cpController := RSBlockCPController new
 		block: [ :edge |
@@ -125,7 +125,7 @@ RSForceLayoutInSpaces >> fill: space with: aCollection [
 ]
 
 { #category : #initialization }
-RSForceLayoutInSpaces >> initialize [
+RSForceLayoutInSpacesBuilder >> initialize [
 	super initialize.
 	colorForLinesInSameSpace := Color blue muchDarker alpha: 0.8.
 	colorForLinesInDifferentSpace := Color blue muchDarker alpha: 0.1.
@@ -134,7 +134,7 @@ RSForceLayoutInSpaces >> initialize [
 ]
 
 { #category : #shapes }
-RSForceLayoutInSpaces >> newShapeFor: aClass [
+RSForceLayoutInSpacesBuilder >> newShapeFor: aClass [
 	^ RSEllipse new
 		popup;
 		model: aClass;
@@ -144,7 +144,7 @@ RSForceLayoutInSpaces >> newShapeFor: aClass [
 ]
 
 { #category : #shapes }
-RSForceLayoutInSpaces >> newSpaceFor: model [
+RSForceLayoutInSpacesBuilder >> newSpaceFor: model [
 	| space layout |
 	layout := RSRectangleForceLayout new
 		start;
@@ -161,17 +161,17 @@ RSForceLayoutInSpaces >> newSpaceFor: model [
 ]
 
 { #category : #accessing }
-RSForceLayoutInSpaces >> numberOfSpaces [
+RSForceLayoutInSpacesBuilder >> numberOfSpaces [
 	^ numberOfSpaces
 ]
 
 { #category : #accessing }
-RSForceLayoutInSpaces >> numberOfSpaces: anInteger [ 
+RSForceLayoutInSpacesBuilder >> numberOfSpaces: anInteger [ 
 	numberOfSpaces := anInteger
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> renderIn: aCanvas [
+RSForceLayoutInSpacesBuilder >> renderIn: aCanvas [
 	spaces := (1 to: numberOfSpaces) collect: [ :i | self newSpaceFor: i ].
 	shapes := classes collect: [ :obj | self newShapeFor: obj ] as: RSGroup.
 	self fill: spaces first with: shapes.
@@ -183,7 +183,7 @@ RSForceLayoutInSpaces >> renderIn: aCanvas [
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> updateSpace: space [
+RSForceLayoutInSpacesBuilder >> updateSpace: space [
 	| layout |
 	layout := space propertyAt: #layout.
 	layout center: space position.
@@ -191,6 +191,6 @@ RSForceLayoutInSpaces >> updateSpace: space [
 ]
 
 { #category : #hooks }
-RSForceLayoutInSpaces >> withShapesThatAccompany: shape [
+RSForceLayoutInSpacesBuilder >> withShapesThatAccompany: shape [
 	^ shape model withAllSubclasses collect: [ :cls | self canvas shapeFromModel: cls ].
 ]

--- a/src/Roassal3-Layouts/RSForceLayoutStepping.class.st
+++ b/src/Roassal3-Layouts/RSForceLayoutStepping.class.st
@@ -101,7 +101,7 @@ RSForceLayoutStepping >> startForceAnimation: aCanvas [
 	animation := aCanvas animationFrom: {
 		"Start smoothly"
 		aCanvas transitionAnimation
-			easing: RSEasing cubicOut;
+			easing: RSEasingInterpolator cubicOut;
 			duration: 500 milliSeconds;
 			range: self alphaRange;
 			onStepDo: [ :t | layout alpha: t; step ].
@@ -117,7 +117,7 @@ RSForceLayoutStepping >> startForceAnimation: aCanvas [
 RSForceLayoutStepping >> startSimpleAnimation: aCanvas [
 	animation ifNotNil: #stop.
 	animation := aCanvas newAnimation 
-		easing: RSEasing cubicInOut;
+		easing: RSEasingInterpolator cubicInOut;
 		range: self alphaRange reversed;
 		duration: 2 seconds;
 		onStepDo: [ :t | layout alpha: t; step  ];

--- a/src/Roassal3-Legend-Examples/RSLegendExamples.class.st
+++ b/src/Roassal3-Legend-Examples/RSLegendExamples.class.st
@@ -11,7 +11,7 @@ Class {
 RSLegendExamples >> example01Basic [ 
 	<script: 'self new example01Basic open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b text: 'Circle = classes, size = number of methods; gray links = inheritance;'.
 	b text: 'Blue links = dependencies; layout = force based layout on the inheritance links'.
 	b build.
@@ -25,7 +25,7 @@ RSLegendExamples >> example01Basic [
 RSLegendExamples >> example02Border [
 	<script: 'self new example02Border open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b text: 'Circle = classes, size = number of methods; gray links = inheritance;'.
 	b text: 'Blue links = dependencies; layout = force based layout on the inheritance links'.
 	b legendDo: [ :l | 
@@ -41,7 +41,7 @@ RSLegendExamples >> example02Border [
 RSLegendExamples >> example03Vertical [
 	<script: 'self new example03Vertical open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b 
 		title: 'Mid Heros';
 		text: 'Invoker';
@@ -62,7 +62,7 @@ RSLegendExamples >> example03Vertical [
 RSLegendExamples >> example04Horizontal [
 	<script: 'self new example04Horizontal open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b 
 		text: 'Invoker';
 		text: 'Shadow Fiend';
@@ -83,7 +83,7 @@ RSLegendExamples >> example04Horizontal [
 RSLegendExamples >> example05Colors [
 	<script: 'self new example05Colors open'>
 	| b color |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	
 	color := NSScale category20.
 	b 
@@ -105,7 +105,7 @@ RSLegendExamples >> example05Colors [
 RSLegendExamples >> example06BoxColors [
 	<script: 'self new example06BoxColors open'>
 	| b color |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 
 	color := NSScale category20.
 	b 
@@ -127,7 +127,7 @@ RSLegendExamples >> example06BoxColors [
 RSLegendExamples >> example07BoxFading [
 	<script: 'self new example07BoxFading open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b title: 'Legend'.
 	b text: 'Number of lines of code' withFadingRamp: {0->'black'. 1->'red'}.
 	b legendDo: [:l | l withBorder; padding: 10 ].
@@ -140,7 +140,7 @@ RSLegendExamples >> example07BoxFading [
 RSLegendExamples >> example08Polygons [
 	<script: 'self new example08Polygons open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b title: 'Polygons'.
 	#(diamond triangle star pentagon octagon) do: [ :selector | 
 		b text: selector withShape: ((RSShapeFactory perform: selector) size: 15) ].
@@ -153,7 +153,7 @@ RSLegendExamples >> example08Polygons [
 RSLegendExamples >> example09Lines [
 	<script: 'self new example09Lines open'>
 	| b |
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b title: 'Line with markers'.
 	#(diamond triangle star pentagon octagon arrow) do: [ :selector |
 		| line marker |
@@ -194,7 +194,7 @@ RSLegendExamples >> example10Location [
 		shapes: classes;
 		normalize: #numberOfMethods.
 	RSTreeLayout on: classes.
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b container: canvas.
 	b title: 'System complexity view'.
 	b text: 'Number of lines of code' withFadingRamp: { 0->'black'. 1->'red'}.
@@ -245,7 +245,7 @@ RSLegendExamples >> example11OnDemand [
 		shapes: classes;
 		normalize: #numberOfMethods.
 	RSTreeLayout on: classes.
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b container: canvas.
 	b title: 'System complexity view'.
 	b text: 'Number of lines of code' withFadingRamp: { 0->'black'. 1->'red'}.
@@ -299,7 +299,7 @@ RSLegendExamples >> example12OnPopup [
 		| composite lb colors |
 		composite := RSComposite new.
 		colors := NSScale category20c.
-		lb := RSLegend new.
+		lb := RSLegendBuilder new.
 		lb container: composite.
 		lb title: cls name.
 		cls methods 

--- a/src/Roassal3-Legend/RSLegendBuilder.class.st
+++ b/src/Roassal3-Legend/RSLegendBuilder.class.st
@@ -27,7 +27,7 @@ c
 ```
 "
 Class {
-	#name : #RSLegend,
+	#name : #RSLegendBuilder,
 	#superclass : #RSAbstractContainerBuilder,
 	#instVars : [
 		'layout',
@@ -44,7 +44,7 @@ Class {
 }
 
 { #category : #hooks }
-RSLegend >> basicRenderIn: aCanvas [
+RSLegendBuilder >> basicRenderIn: aCanvas [
 	| legend |
 	legend := self legend.
 	location move: legend on: aCanvas shapes.
@@ -52,7 +52,7 @@ RSLegend >> basicRenderIn: aCanvas [
 ]
 
 { #category : #'public - specific' }
-RSLegend >> customText: anObject shape: aShape [
+RSLegendBuilder >> customText: anObject shape: aShape [
 	| shape |
 	"general propuse, you can add and define anything in aShape to be a legend"
 	shape := aShape copy text: anObject.
@@ -61,60 +61,60 @@ RSLegend >> customText: anObject shape: aShape [
 ]
 
 { #category : #accessing }
-RSLegend >> defaultBoldText [
+RSLegendBuilder >> defaultBoldText [
 	^ defaultBoldText ifNil: [ defaultBoldText := RSLabel new bold ].
 ]
 
 { #category : #accessing }
-RSLegend >> defaultBox [
+RSLegendBuilder >> defaultBox [
 	^ defaultBox ifNil: [ defaultBox := RSBox new size: 15 ].
 ]
 
 { #category : #accessing }
-RSLegend >> defaultCircle [
+RSLegendBuilder >> defaultCircle [
 	^ defaultCircle ifNil: [ defaultCircle := RSEllipse new size: 15. ]
 ]
 
 { #category : #accessing }
-RSLegend >> defaultLabel [
+RSLegendBuilder >> defaultLabel [
 	^ defaultLabel ifNil: [ defaultLabel := RSLabel new ].
 ]
 
 { #category : #accessing }
-RSLegend >> defaultLabel: aShape [
+RSLegendBuilder >> defaultLabel: aShape [
 	defaultLabel := aShape
 ]
 
 { #category : #accessing }
-RSLegend >> defaultTitle [
+RSLegendBuilder >> defaultTitle [
 	^ defaultTitle ifNil: [ defaultTitle := RSLabel new bold.
 		defaultTitle fontSize: defaultTitle fontSize * 1.2.
 		defaultTitle ].
 ]
 
 { #category : #accessing }
-RSLegend >> defaultTitle: aShape [
+RSLegendBuilder >> defaultTitle: aShape [
 	defaultTitle := aShape
 ]
 
 { #category : #initialization }
-RSLegend >> initialize [
+RSLegendBuilder >> initialize [
 	super initialize.
 	self reset.
 ]
 
 { #category : #testing }
-RSLegend >> isOnDemand [
+RSLegendBuilder >> isOnDemand [
 	^ menuShape notNil
 ]
 
 { #category : #layout }
-RSLegend >> layout [ 
+RSLegendBuilder >> layout [ 
 	^ layout
 ]
 
 { #category : #accessing }
-RSLegend >> legend [
+RSLegendBuilder >> legend [
 	| legend |
 	layout on: self shapes.
 	legend := RSComposite new
@@ -125,27 +125,27 @@ RSLegend >> legend [
 ]
 
 { #category : #public }
-RSLegend >> legendDo: aBlock [
+RSLegendBuilder >> legendDo: aBlock [
 	legendBlock := aBlock
 ]
 
 { #category : #accessing }
-RSLegend >> location [
+RSLegendBuilder >> location [
 	^ location
 ]
 
 { #category : #accessing }
-RSLegend >> menuShape [
+RSLegendBuilder >> menuShape [
 	^ menuShape
 ]
 
 { #category : #public }
-RSLegend >> onDemand [
+RSLegendBuilder >> onDemand [
 	^ self onDemand: 'Help'.
 ]
 
 { #category : #public }
-RSLegend >> onDemand: text [
+RSLegendBuilder >> onDemand: text [
 	^ menuShape := RSLabel new
 		text: text;
 		color: Color lightGray;
@@ -154,7 +154,7 @@ RSLegend >> onDemand: text [
 ]
 
 { #category : #'public - specific' }
-RSLegend >> polymetricWidth: labelWidth height: labelHeight box: labelBox [
+RSLegendBuilder >> polymetricWidth: labelWidth height: labelHeight box: labelBox [
 	"very very specific shape"
 	| box s marker line g l1 l2 l3 line1 line2  |
 	box := RSBox new
@@ -183,7 +183,7 @@ RSLegend >> polymetricWidth: labelWidth height: labelHeight box: labelBox [
 ]
 
 { #category : #hooks }
-RSLegend >> renderIn: aCanvas [
+RSLegendBuilder >> renderIn: aCanvas [
 	self isOnDemand 
 		ifTrue: [ self renderOnDemandIn: aCanvas ]
 		ifFalse: [self basicRenderIn: aCanvas ].
@@ -191,7 +191,7 @@ RSLegend >> renderIn: aCanvas [
 ]
 
 { #category : #hooks }
-RSLegend >> renderOnDemandIn: aCanvas [
+RSLegendBuilder >> renderOnDemandIn: aCanvas [
 	| i legendLabels update |
 	menuShape isFixed: true.
 	aCanvas addShape: menuShape.
@@ -218,7 +218,7 @@ RSLegend >> renderOnDemandIn: aCanvas [
 ]
 
 { #category : #initialization }
-RSLegend >> reset [
+RSLegendBuilder >> reset [
 	legendBlock := [ :l | l draggable ].
 	shapes := RSGroup new.
 	location := RSLocation new below.
@@ -231,7 +231,7 @@ RSLegend >> reset [
 ]
 
 { #category : #utilities }
-RSLegend >> shape: aShape withColor: color [
+RSLegendBuilder >> shape: aShape withColor: color [
 	| copy |
 	copy := aShape copy.
 	copy color: (color rsValue: copy).
@@ -239,12 +239,12 @@ RSLegend >> shape: aShape withColor: color [
 ]
 
 { #category : #public }
-RSLegend >> text: aString [
+RSLegendBuilder >> text: aString [
 	^ self customText: aString shape: self defaultLabel
 ]
 
 { #category : #public }
-RSLegend >> text: aString description: desc [
+RSLegendBuilder >> text: aString description: desc [
 	| text tshapes line l d|
 	text := self defaultBoldText copy.
 	text text: aString.
@@ -260,17 +260,17 @@ RSLegend >> text: aString description: desc [
 ]
 
 { #category : #public }
-RSLegend >> text: aString withBoxColor: color [
+RSLegendBuilder >> text: aString withBoxColor: color [
 	^ self text: aString withShape: (self shape: self defaultBox withColor: color).
 ]
 
 { #category : #public }
-RSLegend >> text: aString withCircleColor: color [
+RSLegendBuilder >> text: aString withCircleColor: color [
 	^ self text: aString withShape: (self shape: self defaultCircle withColor: color).
 ]
 
 { #category : #'public - specific' }
-RSLegend >> text: aString withFadingRamp: ramp [
+RSLegendBuilder >> text: aString withFadingRamp: ramp [
 	| gradient s |
 	"very specific shape"
 	gradient := LinearGradientPaint fromArray: ramp.
@@ -284,7 +284,7 @@ RSLegend >> text: aString withFadingRamp: ramp [
 ]
 
 { #category : #public }
-RSLegend >> text: aString withShape: aShape [
+RSLegendBuilder >> text: aString withShape: aShape [
 	| text tshapes line l |
 	text := self defaultLabel copy.
 	text text: aString.
@@ -299,12 +299,12 @@ RSLegend >> text: aString withShape: aShape [
 ]
 
 { #category : #public }
-RSLegend >> title: aString [
+RSLegendBuilder >> title: aString [
 	^ self customText: aString shape: self defaultTitle
 ]
 
 { #category : #public }
-RSLegend >> withFrame [
+RSLegendBuilder >> withFrame [
 	"Set a frame around the legend"
 	self legendDo: [ :l |
 		l 

--- a/src/Roassal3-Mondrian/RSConnectionExample.class.st
+++ b/src/Roassal3-Mondrian/RSConnectionExample.class.st
@@ -46,7 +46,7 @@ RSConnectionExample >> example02TwoViews [
 
 	connection output: [ :inputModel | 
 		| c3 |
-		c3 := RSChart new.
+		c3 := RSChartBuilder new.
 		d := RSLinePlot new.
 		d y:
 			(((1 to: inputModel) collect: [ :v | Random new nextInt: 42 ]) 

--- a/src/Roassal3-Pie-Examples/RSPieExamples.class.st
+++ b/src/Roassal3-Pie-Examples/RSPieExamples.class.st
@@ -41,7 +41,7 @@ RSPieExamples >> example01Basic [
 	<script: 'self new example01Basic open'>
 	| classes pie |
 	classes :={Dictionary. OrderedCollection. String. Set. Array}.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: classes;
 		slice: #numberOfMethods;
 		yourself.
@@ -55,7 +55,7 @@ RSPieExamples >> example02Emphasize [
 	<script: 'self new example02Emphasize open'>
 	| classes pie |
 	classes :={Dictionary. OrderedCollection. String. Set. Array}.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: classes;
 		slice: #numberOfMethods;
 		yourself.
@@ -72,7 +72,7 @@ RSPieExamples >> example03BasicColors [
 	<script: 'self new example03BasicColors open'>
 	| classes pie |
 	classes :={Dictionary. OrderedCollection. String. Set. Array}.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: classes;
 		slice: #numberOfMethods;
 		yourself.
@@ -91,7 +91,7 @@ RSPieExamples >> example03BasicColors [
 RSPieExamples >> example04SegmentSpacingAnimation [
 	<script: 'self new example04SegmentSpacingAnimation open'>
 	| pie |
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: #(3 3 2 2 5 8 14);
 		yourself.
 	pie sliceShape
@@ -104,7 +104,7 @@ RSPieExamples >> example04SegmentSpacingAnimation [
 		build.
 	pie canvas newAnimation 
 		repeat;
-		easing: RSEasing sinIn;
+		easing: RSEasingInterpolator sinIn;
 		duration: 5 seconds;
 		from: 0; 
 		to: 180;
@@ -121,7 +121,7 @@ RSPieExamples >> example05Smash [
 	<script: 'self new example05Smash open'>
 	| pie r |
 	r := Random new.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: ((1 to: 10) collect: [:e | r next]) sort;
 		yourself.
 	pie sliceShape
@@ -137,7 +137,7 @@ RSPieExamples >> example05Smash [
 		pie canvas animationFrom: { 
 			(pie canvas transitionAnimation 
 				duration: 2 seconds;
-				easing: RSEasing bounceOut;
+				easing: RSEasingInterpolator bounceOut;
 				onStepDo: [ :t |
 					shape 
 						alphaAngle: a * t;
@@ -145,7 +145,7 @@ RSPieExamples >> example05Smash [
 			(pie canvas transitionAnimation 
 				delay: (50 * index) milliSeconds;
 				duration: 750 milliSecond;
-				easing: RSEasing elasticOut;
+				easing: RSEasingInterpolator elasticOut;
 				from: 0;
 				to: 120;
 				on: shape shape set: #innerRadius: ) }. ].
@@ -157,7 +157,7 @@ RSPieExamples >> example05Smash [
 RSPieExamples >> example06SmashHSL [
 	<script: 'self new example06SmashHSL open'>
 	| pie |
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: (1 to: 360);
 		yourself.
 	pie sliceShape
@@ -173,7 +173,7 @@ RSPieExamples >> example06SmashHSL [
 		pie canvas animationFrom: { 
 			(pie canvas transitionAnimation 
 				duration: 2 seconds;
-				easing: RSEasing bounceOut;
+				easing: RSEasingInterpolator bounceOut;
 				onStepDo: [ :t |
 					shape 
 						alphaAngle: a * t;
@@ -181,7 +181,7 @@ RSPieExamples >> example06SmashHSL [
 			(pie canvas transitionAnimation 
 				delay: (10 * index) milliSeconds;
 				duration: 2 seconds;
-				easing: (RSEasing elasticOut period: 0.30; amplitude: 0.8) ;
+				easing: (RSEasingInterpolator elasticOut period: 0.30; amplitude: 0.8) ;
 				from: 0;
 				to: 120;
 				on: shape shape set: #innerRadius: ) }. ].
@@ -195,7 +195,7 @@ RSPieExamples >> example07Dendi [
 	<script: 'self new example07Dendi open'>
 	| pie r |
 	r := Random new.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: ((1 to: 10) collect: [:e | r next]) sort;
 		yourself.
 	pie sliceShape
@@ -209,14 +209,14 @@ RSPieExamples >> example07Dendi [
 		b := shape betaAngle.
 		pie canvas animationFrom: { 
 			(pie canvas transitionAnimation 
-				easing: RSEasing bounce;
+				easing: RSEasingInterpolator bounce;
 				onStepDo: [ :t |
 					shape 
 						alphaAngle: a * t;
 						betaAngle: b * t ]).
 			(pie canvas transitionAnimation 
 				delay: 3 seconds;
-				easing: RSEasing  bounce;
+				easing: RSEasingInterpolator  bounce;
 				onStepDo: [:t | 
 					shape
 						alphaAngle: a + ((360 - a) * t);
@@ -229,7 +229,7 @@ RSPieExamples >> example07Dendi [
 RSPieExamples >> example08CornerRadii [
 	<script: 'self new example08CornerRadii open'>
 	| pie |
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: #(1 1 2 3 4 8 14 21);
 		yourself.
 	pie sliceShape
@@ -248,7 +248,7 @@ RSPieExamples >> example08CornerRadii [
 RSPieExamples >> example09TickAnimation [
 	<script: 'self new example09TickAnimation open'>
 	| pie |
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	pie objects: (0 to: 360).
 	pie sliceShape
 		externalRadius: 200;
@@ -261,7 +261,7 @@ RSPieExamples >> example09TickAnimation [
 		repeat; 
 		from: 0; 
 		to: 500;
-		easing: RSEasing elasticOut;
+		easing: RSEasingInterpolator elasticOut;
 		onStepDo: [ :t |
 			pie shapes do: [ :s |
 				s color: (Color h: s model  + t s: 1 l: 0.5) ] ].
@@ -273,7 +273,7 @@ RSPieExamples >> example09TickAnimation [
 RSPieExamples >> example10CornerRadiiAnimation [
 	<script: 'self new example10CornerRadiiAnimation open'>
 	| pie |
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	pie objects: #(1 1 2 3 4 8 14 21).
 	
 	pie sliceShape
@@ -304,7 +304,7 @@ RSPieExamples >> example10CornerRadiiAnimation [
 RSPieExamples >> example11OpenningAnimation [
 	<script: 'self new example11OpenningAnimation open'>
 	| pie bounce inout outin reset colors |
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	pie objects: #(1 1 2 3 4 8 14 21) reverse.
 	pie sliceShape
 
@@ -319,7 +319,7 @@ RSPieExamples >> example11OpenningAnimation [
 	reset := [ pie shapes do: #remove. pie build. pie canvas signalUpdate ].
 	
 	bounce := pie canvas transitionAnimation from: 0; to: 360; 
-		easing: RSEasing bounceOut;
+		easing: RSEasingInterpolator bounceOut;
 		onStepDo: [ :t | 
 		pie shapes do: [ :shape | | beta |
 			beta := shape propertyAt: #beta.
@@ -337,7 +337,7 @@ RSPieExamples >> example11OpenningAnimation [
 	
 	inout := pie canvas transitionAnimation 
 		delay: 1 second;
-		easing: RSEasing backOut;
+		easing: RSEasingInterpolator backOut;
 		onStepDo: [ :t |
 			pie shapes do: [ :shape |
 				shape innerRadius: 70 * t.
@@ -347,7 +347,7 @@ RSPieExamples >> example11OpenningAnimation [
 	
 	outin := pie canvas transitionAnimation
 		delay: 1 second;
-		easing: RSEasing elasticOut;
+		easing: RSEasingInterpolator elasticOut;
 		onStepDo: [ :t |
 			pie shapes do: [ :shape | | p a b att |
 				att := shape properties.
@@ -378,7 +378,7 @@ RSPieExamples >> example12RainbowPie [
 	n := 48.
 	d := 100.
 	frame := 0.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: (1 to: n);
 		slice: [:v | 1 ].
 	pie sliceShape
@@ -411,7 +411,7 @@ RSPieExamples >> example13BasicColorNormalize [
 	<script: 'self new example13BasicColorNormalize open'>
 	| classes pie  |
 	classes :=RSEvent withAllSubclasses.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: classes;
 		slice: #numberOfMethods;
 		yourself.
@@ -437,7 +437,7 @@ RSPieExamples >> example14Pyramid [
 	{ 0.7. 'Sky'. Color lightBlue }.
 	{0.2. 'Sunny side of pyramid'. Color yellow darker }.
 	{ 0.05. 'Shady side of pyramid'. Color yellow muchDarker} }.
-	b := RSPie new.
+	b := RSPieBuilder new.
 	b
 		objects: data;
 		slice: #first.
@@ -454,7 +454,7 @@ RSPieExamples >> example14Pyramid [
 RSPieExamples >> example15Clockwise [
 	<script: 'self new example15Clockwise open'>
 	| b r  |
-	b := RSPie new.
+	b := RSPieBuilder new.
 	r := Random new.
 	b objects: ((1 to: 10) collect: [:e | r next]) sort.
 	b sliceShape externalRadius: 200.
@@ -481,7 +481,7 @@ RSPieExamples >> example16MyDay [
 	color := NSScale ordinal
 		rangeFrom: { 'ae579c'. 'f28d1b'. 'e21454'. '4cbcec' }.
 	canvas := RSCanvas new.
-	pie := RSPie new
+	pie := RSPieBuilder new
 		container: canvas;
 		objects: data;
 		slice: #third.
@@ -526,7 +526,7 @@ RSPieExamples >> example17PieLabels [
 		'25-54'->4174931. 
 		'55-64'->657007. 
 		'>=65'->590751}.
-	pie := RSPie new 
+	pie := RSPieBuilder new 
 		objects: data;
 		slice: #value.
 	pie sliceShape
@@ -552,7 +552,7 @@ RSPieExamples >> example18ManyPies [
 	| data pie color canvas shapes pieLabel pieTitle |
 	data := self esportPrizepool.
 	color := NSScale google20.
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	canvas := pie container.
 	pie sliceShape
 		externalRadius: 200;
@@ -620,7 +620,7 @@ RSPieExamples >> example19Buttons [
 	canvas when: RSExtentChangedEvent do: [ canvas zoomToFit; signalUpdate ].
 	canvas @ RSCanvasController.
 	
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	pie 
 		container: canvas;
 		objects: { 1@0. 1@ -1. 0@ -1. -1@ -1. -1@0. -1@1. 0@1. 1@1 };
@@ -652,14 +652,14 @@ RSPieExamples >> example19Buttons [
 				move := shape model.
 				canvas newAnimation 
 					duration: 1 second;
-					easing: RSEasing backOut;
+					easing: RSEasingInterpolator backOut;
 					from: 40; to: 50;
 					on: shape shape set: #externalRadius:. ];
 			when: RSMouseLeave do: [ 
 				move := 0@0.
 				canvas newAnimation 
 					duration: 1 second;
-					easing: RSEasing backOut;
+					easing: RSEasingInterpolator backOut;
 					from: 50; to: 40;
 					on: shape shape set: #externalRadius:. ] ] .
 	^ canvas
@@ -675,7 +675,7 @@ RSPieExamples >> example20AddingRemoving [
 	| pie objects canvas color shapes updatePie labels removed updateLabel update pieClick |
 	objects := String withAllSubclasses.
 	removed := OrderedCollection new.
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	canvas := pie canvas.
 	pie objects: objects;
 		slice: #linesOfCode.
@@ -715,7 +715,7 @@ RSPieExamples >> example20AddingRemoving [
 				detect: [ :e1 | e1 model = shape model ]
 				ifFound: [ :e1|
 					canvas newAnimation 
-						easing: RSEasing quad;
+						easing: RSEasingInterpolator quad;
 						onStepDo: [:t |
 							shape 
 								alphaAngle: (e1 alphaAngle interpolateTo: x at: t);
@@ -729,7 +729,7 @@ RSPieExamples >> example20AddingRemoving [
 			shape := pie shapes last.
 			x := shape alphaAngle.
 			canvas newAnimation
-				easing: RSEasing quad;
+				easing: RSEasingInterpolator quad;
 				onStepDo: [ :t |
 					shape 
 						alphaAngle: (shape betaAngle interpolateTo: x at: t);
@@ -766,7 +766,7 @@ RSPieExamples >> example21ProgressLabel [
 		select: [ :s | 'Roassal3*' match: s  ]
 		thenCollect: [ :s | org packageNamed: s ]) 
 		sorted: [:a :b | a linesOfCode < b linesOfCode ].
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: data;
 		slice: #linesOfCode.
 	scale := NSScale eva10.
@@ -792,7 +792,7 @@ RSPieExamples >> example22RotatedAnimation [
 		select: [ :s | '*Roassal3*' match: s  ]
 		thenCollect: [ :s | org packageNamed: s ]) 
 		sorted: [:a :b | a linesOfCode < b linesOfCode ].
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: data;
 		slice: #linesOfCode.
 	canvas := pie canvas.
@@ -847,7 +847,7 @@ RSPieExamples >> example23RotatedAnimation [
 		sum ].
 	data := data sort: [ :a :b |
 		(directorySize value: a) > (directorySize value: b) ].
-	pie := RSPie new
+	pie := RSPieBuilder new
 		objects: data;
 		slice: [:dir | (directorySize value: dir) sqrt ].
 	canvas := pie canvas.
@@ -931,7 +931,7 @@ RSPieExamples >> example24ManyPies [
 	radius := NSScale sqrt domain: { 0. maxSum }; range: #(0 220).
 	color := NSScale eva10.
 	canvas := RSCanvas new.
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	pie sliceShape segmentSpacing: 0.5.
 	pie sliceColor: [ :slice | color scale: slice index ].
 
@@ -977,7 +977,7 @@ RSPieExamples >> example24ManyPies [
 RSPieExamples >> example25Massiva [
 	<script: 'self new example25Massiva open'>
 	| pie canvas triangles icons |
-	pie := RSPie new.
+	pie := RSPieBuilder new.
 	canvas := pie container.
 	canvas color: '1E2D72'.
 	pie objects: #( 

--- a/src/Roassal3-Pie/RSPieBuilder.class.st
+++ b/src/Roassal3-Pie/RSPieBuilder.class.st
@@ -18,7 +18,7 @@ b open
 .=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=
 "
 Class {
-	#name : #RSPie,
+	#name : #RSPieBuilder,
 	#superclass : #RSAbstractShapesBuilder,
 	#instVars : [
 		'objects',
@@ -32,18 +32,18 @@ Class {
 }
 
 { #category : #'accessing - computed' }
-RSPie >> alphaAngleFor: aShape [
+RSPieBuilder >> alphaAngleFor: aShape [
 	values ifNil: [ self slice: #yourself ].
 	^ (sumValues at: aShape index) * 360 / totalSum.
 ]
 
 { #category : #'accessing - computed' }
-RSPie >> betaAngleFor: aShape [
+RSPieBuilder >> betaAngleFor: aShape [
 	^ ((sumValues at: aShape index) + (values at: aShape index )) * 360 / totalSum.
 ]
 
 { #category : #initialization }
-RSPie >> initialize [
+RSPieBuilder >> initialize [
 	super initialize.
 	self sliceColor: [ :slice | 
 		slice index even 
@@ -57,17 +57,17 @@ RSPie >> initialize [
 ]
 
 { #category : #accessing }
-RSPie >> objects [
+RSPieBuilder >> objects [
 	^ objects
 ]
 
 { #category : #accessing }
-RSPie >> objects: someObjects [
+RSPieBuilder >> objects: someObjects [
 	objects := someObjects
 ]
 
 { #category : #hooks }
-RSPie >> shapeFor: anObject [
+RSPieBuilder >> shapeFor: anObject [
 	| slice |
 	slice := self sliceShape copy.
 	slice
@@ -80,7 +80,7 @@ RSPie >> shapeFor: anObject [
 ]
 
 { #category : #hooks }
-RSPie >> shapeFor: anObject index: index [
+RSPieBuilder >> shapeFor: anObject index: index [
 	| slice |
 	slice := self sliceShape copy.
 	slice
@@ -94,7 +94,7 @@ RSPie >> shapeFor: anObject index: index [
 ]
 
 { #category : #public }
-RSPie >> slice: aBlockOrASymbol [
+RSPieBuilder >> slice: aBlockOrASymbol [
 	"Set the way we give a pie share for each element."
 	| tempSum |
 	values := objects collect: [:m | aBlockOrASymbol value: m value ] as: Array.
@@ -108,30 +108,30 @@ RSPie >> slice: aBlockOrASymbol [
 ]
 
 { #category : #accessing }
-RSPie >> sliceColor [
+RSPieBuilder >> sliceColor [
 	^ sliceColor
 ]
 
 { #category : #accessing }
-RSPie >> sliceColor: anObject [
+RSPieBuilder >> sliceColor: anObject [
 	"a block or object that can anwser rsValue:"
 	sliceColor := anObject 
 	
 ]
 
 { #category : #accessing }
-RSPie >> sliceShape [
+RSPieBuilder >> sliceShape [
 	"you can modify with simples values all atributes of slices except color and angles"
 	"review #sliceColor and #slice:"
 	^ sliceShape
 ]
 
 { #category : #'accessing - computed' }
-RSPie >> totalSum [
+RSPieBuilder >> totalSum [
 	^ totalSum
 ]
 
 { #category : #accessing }
-RSPie >> values [
+RSPieBuilder >> values [
 	^ values
 ]

--- a/src/Roassal3-SVG-Examples/RSChartExample.extension.st
+++ b/src/Roassal3-SVG-Examples/RSChartExample.extension.st
@@ -13,7 +13,7 @@ RSChartExample >> example13AreaPlot [
 	'Between y2 and 1'-> (y1 -> 1).
 	'Between y1 and y2'-> (y1 -> y2)} collect: [ :assoc | | g |
 		g := RSGroup new.
-		c := RSChart new.
+		c := RSChartBuilder new.
 		c container: g.
 		c extent: 500@100.
 		c addPlot: (RSAreaPlot new x: x y1: assoc value key y2: assoc value value).
@@ -50,7 +50,7 @@ RSChartExample >> example14AreaPlotWithError [
 		((x - x average) raisedTo: 2) sum) ) sqrt. 
 		
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c padding: 10@10.
 	c addPlot: (RSAreaPlot new x: x y1: y_est + y_err y2: y_est - y_err; color: (Color blue alpha: 0.1) ).
 	c addPlot: (RSLinePlot new x: x y: y_est; color: Color red).
@@ -67,7 +67,7 @@ RSChartExample >> example15AreaBox [
 	x := #(0 1 2 3).
 	y1 := #(0.8 0.8 0.2 0.2).
 	y2 := #(0 0 1 1).
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 150@50.
 	c addPlot: (RSAreaPlot new x: x y1: y1 y2: y2).
 	c addPlot: (RSLinePlot new x: x y: y1; color: Color red; fmt: 's--').
@@ -87,10 +87,10 @@ RSChartExample >> example16Series [
 		sum := 0.
 		arr collect: [ :v | sum := sum + v. sum ] ].
 
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 400@400.
 
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b container: c canvas.
 	b layout horizontal gapSize: 30.
 	#(
@@ -147,7 +147,7 @@ RSChartExample >> example17CLPvsUSD [
 			dates add: d.
 			y add: f ].
 	x := 1 to: dates size.
-	c := RSChart new.
+	c := RSChartBuilder new.
 	c extent: 300@200.
 	plot := RSAreaPlot new x: x y1: y y2: 750.
 	paint := LinearGradientPaint fromArray: 

--- a/src/Roassal3-SVG-Examples/RSSVGAnimationExamples.class.st
+++ b/src/Roassal3-SVG-Examples/RSSVGAnimationExamples.class.st
@@ -79,7 +79,7 @@ RSSVGAnimationExamples >> example02Miku [
 			color: line value;
 			yourself ] ).
 	canvas @ RSCanvasController.
-	easing := RSEasing elasticOut.
+	easing := RSEasingInterpolator elasticOut.
 	canvas nodes do: [ :e | | position |
 		position := (random next * 1000) @ (random next * 1000) - 100.
 		canvas newAnimation
@@ -239,7 +239,7 @@ RSSVGAnimationExamples >> example04RoassalIcon [
 				c newAnimation
 					from: 0;
 					to: 20.4;
-					easing: RSEasing elasticOut;
+					easing: RSEasingInterpolator elasticOut;
 					on: shape set: #radius:.  ] ].
 	eAnimation value: 1 value: c shapes second.
 	eAnimation value: 2000 value: c shapes third.

--- a/src/Roassal3-SVG-Examples/RSSVGShapeExamples.class.st
+++ b/src/Roassal3-SVG-Examples/RSSVGShapeExamples.class.st
@@ -125,7 +125,7 @@ RSSVGShapeExamples >> example02SpockLizard [
 				yourself) asMarker
 				offset: -90;
 				yourself)  ].  
-	lb := RSLegend new.
+	lb := RSLegendBuilder new.
 	lb defaultLabel fontSize: 50.
 	lb container: canvas.
 	lb legendDo: [ :l |l withBorder;padding: 50 ].

--- a/src/Roassal3-Spec-Examples/RSPieChartExample.class.st
+++ b/src/Roassal3-Spec-Examples/RSPieChartExample.class.st
@@ -121,7 +121,7 @@ RSPieChartExample >> visualizeChart: canvas package: pkg [
 { #category : #initialization }
 RSPieChartExample >> visualizePie: canvas package: pkg [
 	| b rect max |
-	b := RSPie new.
+	b := RSPieBuilder new.
 	b container: canvas.
 	
 	b sliceShape

--- a/src/Roassal3-Sunburst-Examples/RSSunburstExamples.class.st
+++ b/src/Roassal3-Sunburst-Examples/RSSunburstExamples.class.st
@@ -165,7 +165,7 @@ RSSunburstExamples >> example08SunburstExplorer [
 	newAnimation := [ :from :to |
 		canvas newAnimation
 			"duration: 500 milliSeconds;"
-			easing: RSEasing bounceOut;
+			easing: RSEasingInterpolator bounceOut;
 			from: from;
 			to: to;
 			yourself ].

--- a/src/Roassal3-Sunburst/RSSunburstBuilder.class.st
+++ b/src/Roassal3-Sunburst/RSSunburstBuilder.class.st
@@ -24,13 +24,13 @@ RSSunburstBuilder >> color: aBlock [
 
 { #category : #strategry }
 RSSunburstBuilder >> constantWidthStrategy [
-	self strategy: RSSunburstConstantWidthStrategy new.
+	self strategy: RSSunburstConstantWidthLayout new.
 	^ strategy
 ]
 
 { #category : #strategry }
 RSSunburstBuilder >> extentStrategy [
-	self strategy: RSSunburstExtentStrategy new.
+	self strategy: RSSunburstExtentLayout new.
 	^ strategy
 ]
 

--- a/src/Roassal3-Sunburst/RSSunburstConstantWidthLayout.class.st
+++ b/src/Roassal3-Sunburst/RSSunburstConstantWidthLayout.class.st
@@ -4,7 +4,7 @@ I am a layout for sunburst visualization,
 I put the arcs in a constant delta separation, you can define the center width.
 "
 Class {
-	#name : #RSSunburstConstantWidthStrategy,
+	#name : #RSSunburstConstantWidthLayout,
 	#superclass : #RSAbstractSunburstLayout,
 	#instVars : [
 		'arcWidth',
@@ -14,40 +14,40 @@ Class {
 }
 
 { #category : #accessing }
-RSSunburstConstantWidthStrategy >> arcWidth [
+RSSunburstConstantWidthLayout >> arcWidth [
 	^ arcWidth
 ]
 
 { #category : #accessing }
-RSSunburstConstantWidthStrategy >> arcWidth: aNumber [
+RSSunburstConstantWidthLayout >> arcWidth: aNumber [
 	arcWidth := aNumber
 ]
 
 { #category : #accessing }
-RSSunburstConstantWidthStrategy >> centerWidth [
+RSSunburstConstantWidthLayout >> centerWidth [
 	^ centerWidth
 ]
 
 { #category : #accessing }
-RSSunburstConstantWidthStrategy >> centerWidth: anObject [
+RSSunburstConstantWidthLayout >> centerWidth: anObject [
 	centerWidth := anObject
 ]
 
 { #category : #'initialize-release' }
-RSSunburstConstantWidthStrategy >> initialize [
+RSSunburstConstantWidthLayout >> initialize [
 	super initialize.
 	self arcWidth: 50.
 	self centerWidth: 50.
 ]
 
 { #category : #hook }
-RSSunburstConstantWidthStrategy >> setCenterRadius: shape [
+RSSunburstConstantWidthLayout >> setCenterRadius: shape [
 	shape externalRadius: self centerWidth.
 	
 ]
 
 { #category : #hook }
-RSSunburstConstantWidthStrategy >> setNormalRadius: shape [
+RSSunburstConstantWidthLayout >> setNormalRadius: shape [
 	| r1 r2 off depth |
 	depth := shape propertyAt: #depth.
 	off := self radialSpacing * (depth-1).

--- a/src/Roassal3-Sunburst/RSSunburstExtentLayout.class.st
+++ b/src/Roassal3-Sunburst/RSSunburstExtentLayout.class.st
@@ -5,7 +5,7 @@ You can use radius to set the total radius of sunburst
 or use the selector extent:, that uses radius size
 "
 Class {
-	#name : #RSSunburstExtentStrategy,
+	#name : #RSSunburstExtentLayout,
 	#superclass : #RSAbstractSunburstLayout,
 	#instVars : [
 		'wside'
@@ -14,18 +14,18 @@ Class {
 }
 
 { #category : #accessing }
-RSSunburstExtentStrategy >> extent: aPoint [
+RSSunburstExtentLayout >> extent: aPoint [
 	wside := aPoint x min: aPoint y
 ]
 
 { #category : #'initialize-release' }
-RSSunburstExtentStrategy >> initialize [
+RSSunburstExtentLayout >> initialize [
 	super initialize.
 	self extent: 500@500
 ]
 
 { #category : #accessing }
-RSSunburstExtentStrategy >> radiusForDepth: depth [
+RSSunburstExtentLayout >> radiusForDepth: depth [
 	| w2 maxDepth |
 	w2 := wside/2.
 	maxDepth := builder maxLevel.
@@ -33,13 +33,13 @@ RSSunburstExtentStrategy >> radiusForDepth: depth [
 ]
 
 { #category : #hook }
-RSSunburstExtentStrategy >> setCenterRadius: shape [
+RSSunburstExtentLayout >> setCenterRadius: shape [
 	shape externalRadius: (self radiusForDepth: 1).
 	
 ]
 
 { #category : #hook }
-RSSunburstExtentStrategy >> setNormalRadius: shape [
+RSSunburstExtentLayout >> setNormalRadius: shape [
 	| r1 r2 off depth |
 	depth := shape propertyAt: #depth.
 	off := self radialSpacing * (depth -1 ).

--- a/src/Roassal3-UML/RSBaselineCalypso.class.st
+++ b/src/Roassal3-UML/RSBaselineCalypso.class.st
@@ -102,7 +102,7 @@ RSBaselineCalypso >> buildLegendOn: canvas [
 	RSHorizontalLineLayout new gapSize: 10; on: miniGraph nodes.
 	miniGraph adjustToChildren.
 	
-	b := RSLegend new.
+	b := RSLegendBuilder new.
 	b container: canvas.
 	b title: 'Dependencies of ', self targetClass name.
 	b text: 'A loaded baseline' withCircleColor: Color gray.


### PR DESCRIPTION
This PR touches these classes:
- RSPopupDecoration => RSChartPopupDecoration

- RSEasing + RSEasingTest => Interpolator

Adding the Builder suffix in:
- RSPie
- RSForceLayoutInSpaces
- RSLegend
- RSChart

- RSAbstractChartElement => RSAbstractChartPlot

Layout instead of strategy in:
- RSSunburstConstantWidthStrategy
- RSSunburstExtentLayout
