### PR TITLE
Renaming the RSEvent hierarchy

### DIFF
--- a/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
@@ -34,7 +34,7 @@ RSBarChartExample >> example01TwoBars [
 	p bars @ RSPopup.
 	
 	p2 bars
-		when: RSMouseEnter do: [ :evt |
+		when: RSMouseEnterEvent do: [ :evt |
 			| color |
 			color := Color random.
 			p2 bars do: [ :shape | shape color: color ].
@@ -267,6 +267,6 @@ RSBarChartExample >> example07DoubleBar [
 	(plot bars, plot bars2) @ RSPopup.
 	title label 
 		addInteraction: (RSPopup text: 'Click to inspect');
-		when: RSMouseClick do: [ :evt | classes inspect ].
+		when: RSMouseClickEvent do: [ :evt | classes inspect ].
 	^ c canvas
 ]

--- a/src/Roassal3-Examples/RSAnimationExamples.class.st
+++ b/src/Roassal3-Examples/RSAnimationExamples.class.st
@@ -73,7 +73,7 @@ RSAnimationExamples >> example02BoxesLineCircles [
 		line 
 			startPoint: lineX@position from y;
 			endPoint: lineX@position to y. ].
-	c when: RSMouseMove do: [ :ev | 
+	c when: RSMouseMoveEvent do: [ :ev | 
 		lineX := ev position x.
 		updateLine value ].
 	update := [ 
@@ -219,7 +219,7 @@ RSAnimationExamples >> example05ElasticEllipses [
 	
 	canvas 
 		when: RSExtentChangedEvent do: [ :evt | canvas zoomToFit ];
-		when: RSMouseClick do: mouseClick.
+		when: RSMouseClickEvent do: mouseClick.
 	^ canvas
 
 ]
@@ -269,7 +269,7 @@ RSAnimationExamples >> example06LinePatterns [
 	].
 	canvas 
 		when: RSExtentChangedEvent do: [ :evt | canvas zoomToFit ];
-		when: RSMouseClick do: [ 
+		when: RSMouseClickEvent do: [ 
 			step := step +1.
 			step > 20 ifTrue: [ step := 0 ] ].
 	^ canvas
@@ -451,12 +451,12 @@ RSAnimationExamples >> example09PerlinParticles [
 			(e propertyAt: #dead) ifTrue: [ e remove ] ].
 		canvas signalUpdate ].
 	
-	canvas when: RSMouseDragging do: [ :evt | 
+	canvas when: RSMouseDraggingEvent do: [ :evt | 
 		1 to: 10 do: [ :i | | p |
 			p := (particle value: evt position->(i+canvas nodes size)).
 			canvas add: p ].
 		canvas signalUpdate ];
-		when: RSKeyUp do: [:evt | 
+		when: RSKeyUpEvent do: [:evt | 
 			evt keyValue = 8 ifTrue: [ 
 				canvas clearBackground: true.
 				canvas nodes copy do: #remove.
@@ -560,12 +560,12 @@ RSAnimationExamples >> example09b [
 			(e propertyAt: #dead) ifTrue: [ e remove ] ].
 		canvas signalUpdate ].
 	
-	canvas when: RSMouseDragging do: [ :evt | 
+	canvas when: RSMouseDraggingEvent do: [ :evt | 
 		1 to: 10 do: [ :i | | p |
 			p := (particle value: evt position-> (i+canvas nodes size) ).
 			canvas add: p ].
 		canvas signalUpdate ];
-		when: RSKeyUp do: [:evt | 
+		when: RSKeyUpEvent do: [:evt | 
 			evt keyValue = 8 ifTrue: [ 
 				canvas clearBackground: true.
 				canvas nodes copy do: #remove.
@@ -1118,7 +1118,7 @@ RSAnimationExamples >> example18Rainbow [
 	canvas
 		when: RSExtentChangedEvent
 		do: [ canvas camera zoomToFit: canvas extent extent: canvas extent ];
-		when: RSMouseClick do: [ 
+		when: RSMouseClickEvent do: [ 
 			mode := mode +1.
 			mode > 2 ifTrue: [mode := 0] ].
 	^ canvas
@@ -1299,7 +1299,7 @@ RSAnimationExamples >> example22Lines [
 	canvas addShape: label.
 	canvas newAnimation repeat from: 0; to: 8; on: label border set: #dashOffset:.
 	
-	canvas when: RSMouseClick do: [
+	canvas when: RSMouseClickEvent do: [
 		step := step + 0.5.
 		step > 11 ifTrue: [ step := 1 ] ].
 	canvas when: RSExtentChangedEvent do: [ canvas camera zoomToFit: canvas extent extent: 640@640 ].
@@ -1615,7 +1615,7 @@ RSAnimationExamples >> example27RSLocate [
 		color: (color scale: 2);
 		yourself.
 	"movableElement size: 40."
-	movableElement when: RSMouseClick do: [ 
+	movableElement when: RSMouseClickEvent do: [ 
 		canvas newAnimation
 			scale: (NSScale linear 
 				domain: #(0 0.5 1); 
@@ -1651,9 +1651,9 @@ RSAnimationExamples >> example27RSLocate [
 			paint: grad1;
 			model: t;
 			addInteraction: labeled;
-			when: RSMouseEnter do: [:evt | evt shape paint: grad2; signalUpdate ]; 
-			when: RSMouseLeave do: [:evt | evt shape paint: grad1; signalUpdate ];
-			when: RSMouseClick do: [:evt | | p |
+			when: RSMouseEnterEvent do: [:evt | evt shape paint: grad2; signalUpdate ]; 
+			when: RSMouseLeaveEvent do: [:evt | evt shape paint: grad1; signalUpdate ];
+			when: RSMouseClickEvent do: [:evt | | p |
 				evt shape model value: locate.
 				p := movableElement position.
 				locate move: movableElement on: fixedElement.
@@ -1871,7 +1871,7 @@ RSAnimationExamples >> example31RoundRectagles [
 			yourself  ] ).
 	canvas when: RSExtentChangedEvent do: [ 
 		canvas camera zoomToFit: canvas extent extent: extent ].
-	canvas when: RSMouseMove do: [ :evt | mouse := evt position. ].
+	canvas when: RSMouseMoveEvent do: [ :evt | mouse := evt position. ].
 	frame := 0.
 	canvas newAnimation repeat onStepDo: [ :t |
 		frame := frame + 1.
@@ -1974,15 +1974,15 @@ RSAnimationExamples >> example33AnimatedLayout [
 		RSLabel new
 			isFixed: true;
 			text: sel capitalized;
-			when: RSMouseLeave do: [ :evt | evt shape 
+			when: RSMouseLeaveEvent do: [ :evt | evt shape 
 				color: Color black; 
 				normal;
 				signalUpdate ];
-			when: RSMouseEnter do: [ :evt | evt shape 
+			when: RSMouseEnterEvent do: [ :evt | evt shape 
 				color: Color blue; 
 				underline;
 				signalUpdate ];
-			when: RSMouseClick do: [ :evt | | pos1 pos2 |
+			when: RSMouseClickEvent do: [ :evt | | pos1 pos2 |
 				pos1 := shapes collect: #position.
 				update value: sel.
 				pos2 := shapes collect: #position.
@@ -2394,7 +2394,7 @@ RSAnimationExamples >> example40Circles [
 			b: 0.6 + (0.4 * (th - (Float pi * 2 / 3) ) cos )
 			alpha: (alpha scale: circleSize) ].
 	canvas 
-		when: RSMouseMove 
+		when: RSMouseMoveEvent 
 		do: [ :evt | updateMouse value: evt position ].
 	updateMouse value: 0@0.
 	frameCount := 0.
@@ -2481,8 +2481,8 @@ RSAnimationExamples >> example41River [
 			])  ].
 	setParticles value.
 	c
-		when: RSMouseClick do: setParticles;
-		when: RSMouseMove do: [ :evt | | alpha |
+		when: RSMouseClickEvent do: setParticles;
+		when: RSMouseMoveEvent do: [ :evt | | alpha |
 			alpha := alphaS scale: evt position x.
 			back color: (Color black alpha: alpha) ].
 	c newAnimation repeat onStepDo: [ :t | 
@@ -2681,9 +2681,9 @@ RSAnimationExamples >> example45Beziers [
 		icon := RSBitmap new form: (self iconNamed: #smallDoIt).
 		button := { icon } asShape.
 		button 
-			when: RSMouseEnter do: [button color: Color lightGray; signalUpdate ];
-			when: RSMouseLeave do: [button color: nil; signalUpdate ];
-			when: RSMouseClick do: [
+			when: RSMouseEnterEvent do: [button color: Color lightGray; signalUpdate ];
+			when: RSMouseLeaveEvent do: [button color: nil; signalUpdate ];
+			when: RSMouseClickEvent do: [
 				comp 
 					propertyAt: #anime
 					ifPresent: [:anime |

--- a/src/Roassal3-Examples/RSBasicAnimationExamples.class.st
+++ b/src/Roassal3-Examples/RSBasicAnimationExamples.class.st
@@ -31,9 +31,9 @@ RSBasicAnimationExamples >> example01Basic [
 		to: 10;
 		on: b border set: 'width:'.
 	c 
-		when:RSMouseClick
+		when:RSMouseClickEvent
 		do: [ c animations do: #pause ];
-		when: RSMouseDoubleClick 
+		when: RSMouseDoubleClickEvent 
 		do: [ c animations do: #continue ].
 	c clearBackground: false.
 	^ c
@@ -67,9 +67,9 @@ RSBasicAnimationExamples >> example02Sequential [
 		loops: 2.
 	
 	c 
-		when:RSMouseClick
+		when:RSMouseClickEvent
 		do: [ c animations do: #pause ];
-		when: RSMouseDoubleClick 
+		when: RSMouseDoubleClickEvent 
 		do: [ c animations do: #continue ].
 	^ c
 ]
@@ -93,9 +93,9 @@ RSBasicAnimationExamples >> example03Ramp [
 		on: b set: #position:.
 	
 	c 
-		when:RSMouseClick
+		when:RSMouseClickEvent
 		do: [ c animations do: #pause ];
-		when: RSMouseDoubleClick 
+		when: RSMouseDoubleClickEvent 
 		do: [ c animations do: #continue ].
 	^ c
 ]
@@ -127,7 +127,7 @@ RSBasicAnimationExamples >> example04DashAnimation [
 		from: 0;
 		to: 8;
 		on: border set: #dashOffset:.
-	box when: RSMouseClick do: [ :a |
+	box when: RSMouseClickEvent do: [ :a |
 		animation isPaused 
 			ifTrue: [ animation continue ]
 			ifFalse: [ animation pause ] ].
@@ -189,7 +189,7 @@ RSBasicAnimationExamples >> example06Parallel [
 		animation
 	}) loops: 2.
 	canvas add: box1; add: box2.
-	canvas when: RSMouseClick do: [ :evt | canvas animations do: #toggle ].
+	canvas when: RSMouseClickEvent do: [ :evt | canvas animations do: #toggle ].
 	^ canvas
 ]
 

--- a/src/Roassal3-Examples/RSBasicShapeExamples.class.st
+++ b/src/Roassal3-Examples/RSBasicShapeExamples.class.st
@@ -177,9 +177,9 @@ RSBasicShapeExamples >> example07EventsMouseMoveDrag [
 			position: evt position;
 			signalUpdate].
 	c
-		when: RSMouseDragging do: [ :evt | 
+		when: RSMouseDraggingEvent do: [ :evt | 
 			update value: evt value: (Color colorFrom: '12A288')];
-		when: RSMouseMove do: [ :evt | 
+		when: RSMouseMoveEvent do: [ :evt | 
 			update value: evt value: (Color colorFrom: 'AB2567') ].
 	c clearBackground: false.
 	^ c
@@ -225,7 +225,7 @@ RSBasicShapeExamples >> example09MouseStep [
 		radius: 0.
 	c addShape: e.
 	prev := 0.
-	c when: RSMouseMove do: [ :evt | 
+	c when: RSMouseMoveEvent do: [ :evt | 
 		dif := (evt position x - prev) abs.
 		prev := evt position x.
 		e 
@@ -247,7 +247,7 @@ RSBasicShapeExamples >> example10EllipseMouseMove [
 	border := RSBorder new color: (Color colorFrom: '002800').
 	b := 1.
 	radius := 200.
-	c when: RSMouseMove do: [ :evt | 
+	c when: RSMouseMoveEvent do: [ :evt | 
 		circleResolution := b.
 		circleResolution isZero ifTrue: [ circleResolution := 0.1 ].
 		angle := Float twoPi / circleResolution.
@@ -298,7 +298,7 @@ RSBasicShapeExamples >> example11ScaleMouseDistance [
 					border: border )
 				] ]
 		].
-	c when: RSMouseMove do: [ :evt | 
+	c when: RSMouseMoveEvent do: [ :evt | 
 		easing := easing + ((evt position - easing)* 1).
 		c shapes copy do: [ :s |
 			zindex := scale scale: (easing distanceTo: s position).
@@ -324,7 +324,7 @@ RSBasicShapeExamples >> example12BasicLine [
 		"rotated"
 		((p x * cos) - (p y * sin))@((p y * cos) + (p x * sin))
 	].
-	c when: RSMouseMove do: [ :evt | 
+	c when: RSMouseMoveEvent do: [ :evt | 
 		size := evt position distanceTo: 0@0.
 		angle := evt position angle + 135 degreesToRadians.
 		c shapes copy do: #remove.
@@ -538,7 +538,7 @@ RSBasicShapeExamples >> example26Polygon [
 		yourself).
 	c shapes first translateTo: 0@0.
 	c showEncompassingRectangles.
-	c shapes first when: RSMouseDragging do: [:evt |
+	c shapes first when: RSMouseDraggingEvent do: [:evt |
 		evt shape translateBy: evt step; signalUpdate].
 	^ c
 ]
@@ -595,7 +595,7 @@ RSBasicShapeExamples >> example30PolygonWithRadius [
 		yourself).
 	c shapes first translateTo: 0@0.
 	c showEncompassingRectangles.
-	c shapes first when: RSMouseDragging do: [:evt |
+	c shapes first when: RSMouseDraggingEvent do: [:evt |
 		evt shape translateBy: evt step; signalUpdate].
 	^ c
 ]
@@ -716,8 +716,8 @@ RSBasicShapeExamples >> example35KeyEvents [
 		s text: (s model, ': ' , evt keyName,', value: ', evt keyValue asString).
 		evt signalUpdate  ].
 	c 
-		when: RSKeyDown do: [ :evt | print value: evt value: down ];
-		when: RSKeyUp do: [ :evt | print value: evt value: up ].
+		when: RSKeyDownEvent do: [ :evt | print value: evt value: down ];
+		when: RSKeyUpEvent do: [ :evt | print value: evt value: up ].
 
 	^ c
 ]
@@ -860,7 +860,7 @@ RSBasicShapeExamples >> example38Interaction [
 		color: Color gray translucent;
 		yourself.
 	c1
-		when: RSMouseClick
+		when: RSMouseClickEvent
 		do: [ :evt | 
 			c1 remove.
 			com removeInteractionIfPresent: RSDraggable.
@@ -892,7 +892,7 @@ RSBasicShapeExamples >> example39YikigeiAnimated [
 	        color: ((Color perform: sel) alpha: 0.4 );
 	        yourself).
 	    ]).
-	c when: RSMouseMove do: [ :evt | 
+	c when: RSMouseMoveEvent do: [ :evt | 
 	    posOffset := (evt position distanceTo: 0@0).
 	    negOffset := posOffset negated.
 	    circles first position: posOffset @ 0.

--- a/src/Roassal3-Examples/RSExpandingBoxes.class.st
+++ b/src/Roassal3-Examples/RSExpandingBoxes.class.st
@@ -26,7 +26,7 @@ RSExpandingBoxes >> initialize [
 	color := NSScale category20b.
 	base := RSComposite new.
 	base popup.
-	base when: RSMouseClick do: [ :evt | self processEvent: evt ].
+	base when: RSMouseClickEvent do: [ :evt | self processEvent: evt ].
 	border := RSBorder new.
 ]
 

--- a/src/Roassal3-Examples/RSHighlightableExamples.class.st
+++ b/src/Roassal3-Examples/RSHighlightableExamples.class.st
@@ -211,15 +211,15 @@ RSHighlightableExamples >> example06IterateNext [
 		outer; right; offset: 70@ -200.
 	numbers do: [ :e | 
 		(legendBuilder text: e model) model: e model  ].
-	numbers, legendBuilder shapes when: RSMouseClick do: [ :evt | highlightBlock value: evt shape model ].
+	numbers, legendBuilder shapes when: RSMouseClickEvent do: [ :evt | highlightBlock value: evt shape model ].
 	legendBuilder build.
 
 	"Unhighlight all when clicking on background."
-	canvas when: RSMouseClick do: unhighlightAllBlock.
+	canvas when: RSMouseClickEvent do: unhighlightAllBlock.
 
 	"Highlight next number when N key is pressed. Initial is nothing"
 	selectedNumber := 0.
-	canvas when: RSKeyUp do: [ :evt |
+	canvas when: RSKeyUpEvent do: [ :evt |
 		evt keyName = #N ifTrue: [
 			selectedNumber := (selectedNumber \\ numbers size) + 1.
 			highlightBlock value: selectedNumber ] ].
@@ -249,7 +249,7 @@ RSHighlightableExamples >> example07HighlightButtons [
 			@ mouseOver; 
 			extent: 120@30;
 			cornerRadius: 3;
-			when: RSMouseClick do: [ :evt |
+			when: RSMouseClickEvent do: [ :evt |
 				mouseOver doUnhighlight: evt shape.
 				selectedButton doHighlight: evt shape.
 				evt signalUpdate ];
@@ -441,7 +441,7 @@ RSHighlightableExamples >> example11ElasticBoxWithCustomDraggable [
 		when: RSSelectionChangedEvent do: [ :evt |
 			high doHighlightShapes: evt selectedShapes ];
 		when: RSSelectionEndEvent do: [:evt | selectedShapes := evt selectedShapes ].
-	canvas nodes when: RSMouseDragging do: [ :evt |
+	canvas nodes when: RSMouseDraggingEvent do: [ :evt |
 		| d |
 		d := evt camera distanceFromPixelToSpace: evt step.
 		(selectedShapes includes: evt shape)

--- a/src/Roassal3-Examples/RSLayoutExamples.class.st
+++ b/src/Roassal3-Examples/RSLayoutExamples.class.st
@@ -583,7 +583,7 @@ RSLayoutExamples >> example20FlowLayout [
 	'VerticalRight'. RSVerticalLineLayout new alignRight.
 	} pairsDo: [:s :layout | 
 		(newLabel value: s)
-			when: RSMouseClick do: [ :evt |
+			when: RSMouseClickEvent do: [ :evt |
 				| last current |
 				last := labels collect: #position.
 				layout on: labels.
@@ -606,7 +606,7 @@ RSLayoutExamples >> example20FlowLayout [
 	} pairsDo: [:s :a |
 		(newLabel value: s)
 			fontSize: 12;
-			when: RSMouseClick do: [ a value. canvas signalUpdate ].
+			when: RSMouseClickEvent do: [ a value. canvas signalUpdate ].
 		].
 	canvas showEncompassingRectangles.
 	RSVerticalLineLayout new gapSize: 3; on: canvas fixedShapes.

--- a/src/Roassal3-Examples/RSShapeExamples.class.st
+++ b/src/Roassal3-Examples/RSShapeExamples.class.st
@@ -457,7 +457,7 @@ RSShapeExamples >> example19Bitmap [
 			form: icon value;
 			model: icon;
 			popupText: #key;
-			when: RSMouseClick do: [ :evt |
+			when: RSMouseClickEvent do: [ :evt |
 				Clipboard clipboardText: evt shape model key.
 				self inform: 'Copied icon name' ].  ].
 	canvas addAll: shapes.
@@ -629,7 +629,7 @@ qui s''alimentent de ta lumière"'.
 	shapeBuilder wrapStrategy: (RSWrapEllipsisStrategy new wrapMaxWidth: 200).
 	canvas add:(shapeBuilder shapeFor: String loremIpsum).
 	RSFlowLayout  on: canvas nodes.
-	canvas nodes when: RSMouseClick do: [ :evt | evt shape inspect ].
+	canvas nodes when: RSMouseClickEvent do: [ :evt | evt shape inspect ].
 	canvas showEncompassingRectangles.
 	
 	^ canvas zoomToFit 
@@ -647,7 +647,7 @@ RSShapeExamples >> example28MultilineLabel [
 				model: met;
 				size: 20;
 				popup;
-				when: RSMouseClick do: [ :evt | evt shape inspect ];
+				when: RSMouseClickEvent do: [ :evt | evt shape inspect ];
 				yourself
 			 ].
 		RSGridLayout on: methods.
@@ -951,7 +951,7 @@ RSShapeExamples >> example36ShapePosition [
 	labelBox translateBy: 100 @ 50.
 	box @ RSDraggable.
 	box
-		when: RSMouseDragging
+		when: RSMouseDraggingEvent
 		do: [ :evt | 
 			labelBox
 				text: 'Box position = ' , evt position asIntegerPoint asString ].

--- a/src/Roassal3-Experimental/RSAlpharo.class.st
+++ b/src/Roassal3-Experimental/RSAlpharo.class.st
@@ -152,7 +152,7 @@ RSAlpharo >> renderIn: aCanvas [
 	self setAnimationsIn: aCanvas.
 	aCanvas addAll: shapes.
 	aCanvas add: self jar.
-	aCanvas when: RSMouseClick send: #removeJar to: self.
+	aCanvas when: RSMouseClickEvent send: #removeJar to: self.
 ]
 
 { #category : #hooks }

--- a/src/Roassal3-Experimental/RSAlpharoExample.class.st
+++ b/src/Roassal3-Experimental/RSAlpharoExample.class.st
@@ -27,7 +27,7 @@ RSAlpharoExample >> example02Classes [
 	b objects: classes.
 	b build.
 	(b shapes collect: [ :s | s children first ]) 
-		when:RSMouseClick 
+		when:RSMouseClickEvent 
 		do: [ :evt | evt shape model browse ].
 	b canvas inspect
 ]

--- a/src/Roassal3-Experimental/RSCat.class.st
+++ b/src/Roassal3-Experimental/RSCat.class.st
@@ -29,7 +29,7 @@ RSCat >> addAnimationSlider [
 		move: label on: slider.
 	ps := NSScale linear domain: #(0 1); range: {0. 6 }.
 	durations := canvas animations collect: [ :a | a duration ].
-	slider when: RSMouseClick do: [ :evt | | p |
+	slider when: RSMouseClickEvent do: [ :evt | | p |
 		p := evt camera fromSpaceToPixel: evt position.
 		p := p x / slider width.
 		red width: p * slider width.

--- a/src/Roassal3-Experimental/RSDelaunayExample.class.st
+++ b/src/Roassal3-Experimental/RSDelaunayExample.class.st
@@ -680,13 +680,13 @@ RSDelaunayExample >> run [
 	"animation for girls"
 	(canvas animationFrom: { self anime1. self anime2. self anime3 }) repeat.
 	
-	canvas when: RSMouseDragging do: [ :evt | 
+	canvas when: RSMouseDraggingEvent do: [ :evt | 
 		allParticles add: (RSParticleD new
 			position: evt position;
 			level: 5;
 			decay: 0.85;
 			yourself) ].
-	canvas when: RSKeyDown do: [ :evt| useFill := useFill not ].
+	canvas when: RSKeyDownEvent do: [ :evt| useFill := useFill not ].
 	canvas open
 		setLabel: 'Delaunay and Chelmico'
 ]
@@ -700,7 +700,7 @@ RSDelaunayExample >> run2 [
 	canvas clearBackground: false.
 	canvas newAnimation repeat onStepDo: [ :t | self step ].
 	maxLevel := 3.
-	canvas when: RSMouseDragging do: [ :evt | 
+	canvas when: RSMouseDraggingEvent do: [ :evt | 
 		allParticles add: (RSParticleD new
 			position: evt position;
 			maxLevel: 3; 

--- a/src/Roassal3-Experimental/RSForceBuilder.class.st
+++ b/src/Roassal3-Experimental/RSForceBuilder.class.st
@@ -111,7 +111,7 @@ RSForceBuilder >> particlesSize: anInteger [
 RSForceBuilder >> renderIn: aCanvas [
 	aCanvas color: colorGenerator backgroundColor.
 	self reset.
-	aCanvas when: RSMouseClick send: #reset to: self.
+	aCanvas when: RSMouseClickEvent send: #reset to: self.
 	aCanvas newAnimation repeat; onStepDo: [ self update: self force ].
 ]
 

--- a/src/Roassal3-Global-Tests/RSMonitorEventsTest.class.st
+++ b/src/Roassal3-Global-Tests/RSMonitorEventsTest.class.st
@@ -18,8 +18,8 @@ RSMonitorEventsTest >> testBasic [
 		timeStamp := evt timeStamp.
 	].
 	
-	canvas announce: RSMouseLeftClick new.
-	self assert: eventClass equals: RSMouseLeftClick.
+	canvas announce: RSMouseLeftClickEvent new.
+	self assert: eventClass equals: RSMouseLeftClickEvent.
 	self assert: timeStamp isNumber.
 	
 	monitor unRegister.

--- a/src/Roassal3-Global-Tests/RSRoassal3Test.class.st
+++ b/src/Roassal3-Global-Tests/RSRoassal3Test.class.st
@@ -36,9 +36,9 @@ RSRoassal3Test >> testRemoveInteractionIfPresent [
 	
 	box := RSBox new.
 	box popup. 
-	self assert: (box announcer handleEventClass: RSMouseMove).
-	box removeInteractionIfPresent: RSMouseMove.
-	self assert: (box announcer handleEventClass: RSMouseMove).
+	self assert: (box announcer handleEventClass: RSMouseMoveEvent).
+	box removeInteractionIfPresent: RSMouseMoveEvent.
+	self assert: (box announcer handleEventClass: RSMouseMoveEvent).
 ]
 
 { #category : #tests }

--- a/src/Roassal3-Inspector-Tests/RSSelectionPresentationTest.class.st
+++ b/src/Roassal3-Inspector-Tests/RSSelectionPresentationTest.class.st
@@ -17,7 +17,7 @@ RSSelectionPresentationTest >> testBasic [
 	c @ RSCanvasController.
 
 	"make sure there is no error when clicking on an element, while being outside the GTInspector"
-	c nodes first announce: RSMouseClick
+	c nodes first announce: RSMouseClickEvent
 
 ]
 
@@ -39,5 +39,5 @@ RSSelectionPresentationTest >> testWithNoCanvas [
 	| shapes |
 	shapes := (1 to: 100) collect: [ :v | RSBox new model: v ] as: RSGroup.
 	shapes @ RSSelectionPresentation.
-	shapes first announce: RSMouseClick
+	shapes first announce: RSMouseClickEvent
 ]

--- a/src/Roassal3-Inspector/RSInspectable.class.st
+++ b/src/Roassal3-Inspector/RSInspectable.class.st
@@ -74,6 +74,6 @@ RSInspectable >> inspectShapeBlock: oneArgBlock [
 { #category : #hooks }
 RSInspectable >> onShape: aShape [
 	aShape 
-		when: RSMouseLeftClick
+		when: RSMouseLeftClickEvent
 		do: [ :evt | self inspectShape: aShape ]
 ]

--- a/src/Roassal3-Inspector/RSSelectionPresentation.class.st
+++ b/src/Roassal3-Inspector/RSSelectionPresentation.class.st
@@ -43,12 +43,12 @@ RSSelectionPresentation >> onShape: aShape [
 	aShape canvas ifNotNil: [ :c | 
 		c propertyAt: #canvasInspectorSelection ifAbsentPut: [ 
 			c removeInteractionIfPresent: self class.
-			c when: RSMouseClick do: [ :evt |
+			c when: RSMouseClickEvent do: [ :evt |
 				self removeShadowOn: evt.
 				evt signalUpdate. ].
 			1 ].
 		 ].
-	aShape when: RSMouseClick do: [ :evt | self selection: evt shape ].
+	aShape when: RSMouseClickEvent do: [ :evt | self selection: evt shape ].
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Interaction-Tests/RSDraggableCanvasTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSDraggableCanvasTest.class.st
@@ -26,20 +26,20 @@ RSDraggableCanvasTest >> testDefault [
 { #category : #tests }
 RSDraggableCanvasTest >> testDraggingModeLeft [
 	canvas @ RSDraggableCanvasInteraction left.
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
 	canvas removeInteractionIfPresent: RSDraggableCanvasInteraction.
 	
 	canvas @ RSDraggableCanvasInteraction left.
-	canvas canvas announce: (RSMouseDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas ).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas ).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
-	canvas canvas announce: (RSMouseLeftDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas ).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseLeftDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas ).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (-10 @ -5)).
 
 
@@ -48,20 +48,20 @@ RSDraggableCanvasTest >> testDraggingModeLeft [
 { #category : #tests }
 RSDraggableCanvasTest >> testDraggingModeMiddle [
 	canvas @ RSDraggableCanvasInteraction middle.
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
 	canvas removeInteractionIfPresent: RSDraggableCanvasInteraction.
 	
 	canvas @ RSDraggableCanvasInteraction middle.
-	canvas canvas announce: (RSMouseDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
-	canvas canvas announce: (RSMouseMiddleDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseMiddleDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (-10 @ -5)).
 
 
@@ -70,20 +70,20 @@ RSDraggableCanvasTest >> testDraggingModeMiddle [
 { #category : #tests }
 RSDraggableCanvasTest >> testDraggingModeRight [
 	canvas @ RSDraggableCanvasInteraction right.
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
 	canvas removeInteractionIfPresent: RSDraggableCanvasInteraction.
 	
 	canvas @ RSDraggableCanvasInteraction right.
-	canvas canvas announce: (RSMouseDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (0 @ 0)).
 	
-	canvas canvas announce: (RSMouseRightDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseRightDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (-10 @ -5)).
 
 
@@ -92,14 +92,14 @@ RSDraggableCanvasTest >> testDraggingModeRight [
 { #category : #tests }
 RSDraggableCanvasTest >> testDraggingOnDraggable [
 	canvas @ RSDraggableCanvasInteraction.
-	canvas canvas announce: (RSMouseDragStart new canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragging new step: 10 @ 5; canvas: canvas canvas).
-	canvas canvas announce: (RSMouseDragEnd new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragStartEvent new canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDraggingEvent new step: 10 @ 5; canvas: canvas canvas).
+	canvas canvas announce: (RSMouseDragEndEvent new canvas: canvas canvas).
 	self assert: (canvas canvas camera position closeTo: (-10 @ -5))
 ]
 
 { #category : #tests }
 RSDraggableCanvasTest >> testDraggingOnNotDraggable [
-	canvas canvas announce: (RSMouseDragging step: 10 @ 5).
+	canvas canvas announce: (RSMouseDraggingEvent step: 10 @ 5).
 	self assert: canvas canvas camera position = (0 @ 0)
 ]

--- a/src/Roassal3-Interaction-Tests/RSElasticBoxTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSElasticBoxTest.class.st
@@ -35,11 +35,11 @@ RSElasticBoxTest >> testEvents [
 		when: RSSelectionChangedEvent do: [ :evt | number := number + 1 ];
 		when: RSSelectionEndEvent do: [ :evt | number := number +10 ].
 	canvas @ elastic.
-	canvas announce: (RSMouseRightDragStart new position: 0@0).
+	canvas announce: (RSMouseRightDragStartEvent new position: 0@0).
 	self assert: number equals: 0.
-	canvas announce: (RSMouseDragging new position: 10@10).
+	canvas announce: (RSMouseDraggingEvent new position: 10@10).
 	self assert: number equals: 1.
-	canvas announce: (RSMouseDragEnd new position: 0@0).
+	canvas announce: (RSMouseDragEndEvent new position: 0@0).
 	self assert: number equals: 11.
 ]
 
@@ -51,6 +51,6 @@ RSElasticBoxTest >> testEventsDraggableCanvas [
 	canvas @ elastic.
 	number := nil.
 	elastic when: RSSelectionStartEvent do: [ :evt | number := 0 ].
-	canvas announce: (RSMouseLeftDragStart new position: 0@0).
+	canvas announce: (RSMouseLeftDragStartEvent new position: 0@0).
 	self assert: number equals: 0.
 ]

--- a/src/Roassal3-Interaction-Tests/RSHighlightableTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSHighlightableTest.class.st
@@ -38,7 +38,7 @@ RSHighlightableTest >> testSameModel [
 	RSGridLayout on: boxes.
 	c @ RSCanvasController.
 	
-	c nodes first announce: RSMouseEnter
+	c nodes first announce: RSMouseEnterEvent
 ]
 
 { #category : #tests }
@@ -68,11 +68,11 @@ RSHighlightableTest >> testWithEdges [
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color gray.
 	
-	shapes second announce: RSMouseEnter.
+	shapes second announce: RSMouseEnterEvent.
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color red.
 	
-	shapes second announce: RSMouseLeave.
+	shapes second announce: RSMouseLeaveEvent.
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color gray.
 
@@ -105,11 +105,11 @@ RSHighlightableTest >> testWithEdges2 [
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color gray.
 	
-	shapes second announce: RSMouseEnter.
+	shapes second announce: RSMouseEnterEvent.
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color black.
 	
-	shapes second announce: RSMouseLeave.
+	shapes second announce: RSMouseLeaveEvent.
 	self assert: (shapes second outgoingLines collect: #color) asSet size equals: 1.
 	self assert: (shapes second outgoingLines collect: #color) anyOne equals: Color gray.
 

--- a/src/Roassal3-Interaction-Tests/RSPopupTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSPopupTest.class.st
@@ -25,7 +25,7 @@ RSPopupTest >> testMultiline [
 	shapes @ RSPopup.
 	self assert: canvas fixedShapes size equals: 0 .
 	
-	shapes last announce: RSMouseMove.
+	shapes last announce: RSMouseMoveEvent.
 	self assert: canvas numberOfShapes equals: shapes size.
 	self assert: canvas fixedShapes size equals: 1.
 	self assert: canvas fixedShapes first shapes second shapes size equals: 2
@@ -33,7 +33,7 @@ RSPopupTest >> testMultiline [
 
 { #category : #tests }
 RSPopupTest >> testNoPopup [
-	shapes first announce: RSMouseEnter.
+	shapes first announce: RSMouseEnterEvent.
 	self assert: canvas numberOfShapes equals: shapes size.
 ]
 
@@ -57,15 +57,15 @@ RSPopupTest >> testPopup [
 
 	self assert: c numberOfShapes equals: 59.
 	self assert: c fixedShapes size equals: 3.
-	shapes first announce: RSMouseMove.
+	shapes first announce: RSMouseMoveEvent.
 	self assert: shapes first model equals: 1.
 	self assert: c numberOfShapes equals: 59.
 	self assert: c fixedShapes size equals: 4.
 	self assert: c fixedShapes last children last text equals: '1'.
 	
-	shapes first announce: RSMouseLeave.
+	shapes first announce: RSMouseLeaveEvent.
 	
-	shapes second announce: RSMouseMove.
+	shapes second announce: RSMouseMoveEvent.
 	self assert: c fixedShapes size equals: 4.
 	self assert: c fixedShapes last children last text equals: '2'.
 ]
@@ -75,7 +75,7 @@ RSPopupTest >> testPopupOnElementNotAddedToAView [
 	| b |
 	b := RSBox new.
 	b @ RSPopup.
-	b announce: RSMouseEnter.
+	b announce: RSMouseEnterEvent.
 	"Should not produce an error"
 ]
 
@@ -89,7 +89,7 @@ RSPopupTest >> testPopupSimple [
 
 	self assert: c numberOfShapes equals: 1.
 	self assert: c fixedShapes isEmpty.
-	c shapes first announce: RSMouseMove.
+	c shapes first announce: RSMouseMoveEvent.
 	self assert: c shapes first model equals: 42.
 	self assert: c numberOfShapes equals: 1.
 	self assert: c fixedShapes size equals: 1.
@@ -116,14 +116,14 @@ RSPopupTest >> testPopupWithoutMouseLeave [
 
 	self assert: c numberOfShapes equals: 59.
 	self assert: c fixedShapes size equals: 3.
-	shapes first announce: RSMouseMove.
+	shapes first announce: RSMouseMoveEvent.
 	self assert: shapes first model equals: 1.
 	self assert: c numberOfShapes equals: 59.
 	self assert: c fixedShapes size equals: 4.
 	self assert: c fixedShapes last children last text equals: '1'.
 	
 	"Note that we do not announce RSMouseLeave"
-	shapes second announce: RSMouseMove.
+	shapes second announce: RSMouseMoveEvent.
 	self assert: c fixedShapes size equals: 4.
 	self assert: c fixedShapes last children last text equals: '2'.
 ]
@@ -133,7 +133,7 @@ RSPopupTest >> testWithPopup [
 	shapes @ RSPopup.
 	self assert: canvas fixedShapes size equals: 0 .
 	
-	shapes first announce: RSMouseMove.
+	shapes first announce: RSMouseMoveEvent.
 	self assert: canvas numberOfShapes equals: shapes size.
 	self assert: canvas fixedShapes size equals: 1.
 ]

--- a/src/Roassal3-Interaction-Tests/RSSearchInCanvasTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSSearchInCanvasTest.class.st
@@ -79,7 +79,7 @@ RSSearchInCanvasTest >> testFixedShapesAndPopup [
 	| lbl |
 	search searchForShapes: '4'.
 	lbl := search fixedLabels first.
-	lbl announce: RSMouseEnter new.
+	lbl announce: RSMouseEnterEvent new.
 ]
 
 { #category : #tests }

--- a/src/Roassal3-Interaction-Tests/RSTransformableTest.class.st
+++ b/src/Roassal3-Interaction-Tests/RSTransformableTest.class.st
@@ -30,13 +30,13 @@ RSTransformableTest >> testBasic02 [
 	interaction := RSTransformable new.
 	shapes @ interaction .
 	s := shapes first.
-	s announce: RSMouseLeftClick new.
+	s announce: RSMouseLeftClickEvent new.
 	self assert: canvas shapes size > shapes size.
 	handles := canvas propertyAt: interaction key.
 	self assert: handles notNil.
 	self assert: handles isNotEmpty.
 	
-	canvas announce: RSMouseClick new.
+	canvas announce: RSMouseClickEvent new.
 	
 	self assert: canvas shapes size equals: shapes size.
 	handles := canvas propertyAt: interaction key.
@@ -83,11 +83,11 @@ RSTransformableTest >> testDrag [
 	interaction := RSTransformable new.
 	shapes @ interaction .
 	s := shapes first.
-	s announce: RSMouseLeftClick new.
+	s announce: RSMouseLeftClickEvent new.
 	self assert: (canvas propertyAt: interaction key) notNil.
-	s announce: RSMouseDragStart new.
+	s announce: RSMouseDragStartEvent new.
 	self assert: (canvas propertyAt: interaction key) isNil.
-	s announce: RSMouseDragEnd new.
+	s announce: RSMouseDragEndEvent new.
 	self assert: (canvas propertyAt: interaction key) notNil.
 ]
 
@@ -97,9 +97,9 @@ RSTransformableTest >> testDrag2 [
 	interaction := RSTransformable new.
 	shapes @ interaction .
 	s := shapes first.
-	s announce: RSMouseDragStart new.
+	s announce: RSMouseDragStartEvent new.
 	self assert: (canvas propertyAt: interaction key) isNil.
-	s announce: RSMouseDragEnd new.
+	s announce: RSMouseDragEndEvent new.
 	self assert: (canvas propertyAt: interaction key) isNil.
 ]
 
@@ -109,7 +109,7 @@ RSTransformableTest >> testUpdateShape [
 	interaction := RSTransformable new.
 	shapes @ interaction .
 	s := shapes first.
-	s announce: RSMouseLeftClick new.
+	s announce: RSMouseLeftClickEvent new.
 	rect := s encompassingRectangle.
 	handles := (canvas propertyAt: interaction key).
 	self assert: handles first class equals: RSPolygon.

--- a/src/Roassal3-Interaction/RSAbstractPopup.class.st
+++ b/src/Roassal3-Interaction/RSAbstractPopup.class.st
@@ -14,13 +14,13 @@ Class {
 
 { #category : #accessing }
 RSAbstractPopup class >> activationEvent [
-	^ RSMouseMove
+	^ RSMouseMoveEvent
 ]
 
 { #category : #accessing }
 RSAbstractPopup class >> removeEvents [
 	^ removeEvents ifNil: [ 
-		removeEvents := { RSMouseClick. RSMouseEnter. RSMouseLeave. RSMouseDragging } ]
+		removeEvents := { RSMouseClickEvent. RSMouseEnterEvent. RSMouseLeaveEvent. RSMouseDraggingEvent } ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Roassal3-Interaction/RSAnimatedPopup.class.st
+++ b/src/Roassal3-Interaction/RSAnimatedPopup.class.st
@@ -9,13 +9,13 @@ Class {
 
 { #category : #accessing }
 RSAnimatedPopup class >> activationEvent [
-	^ RSMouseEnter
+	^ RSMouseEnterEvent
 ]
 
 { #category : #accessing }
 RSAnimatedPopup class >> removeEvents [
 	^ removeEvents ifNil: [ 
-		removeEvents := { RSMouseClick. RSMouseLeave. RSMouseDragging } ]
+		removeEvents := { RSMouseClickEvent. RSMouseLeaveEvent. RSMouseDraggingEvent } ]
 ]
 
 { #category : #hooks }

--- a/src/Roassal3-Interaction/RSDraggable.class.st
+++ b/src/Roassal3-Interaction/RSDraggable.class.st
@@ -15,7 +15,7 @@ RSDraggable class >> wantsUniqueInstance [
 { #category : #hooks }
 RSDraggable >> onShape: aShape [
 	aShape
-		when: RSMouseDragging
+		when: RSMouseDraggingEvent
 		do: [ :evt | 
 			| d |
 			d := evt camera distanceFromPixelToSpace: evt step.

--- a/src/Roassal3-Interaction/RSDraggableCanvasInteraction.class.st
+++ b/src/Roassal3-Interaction/RSDraggableCanvasInteraction.class.st
@@ -37,7 +37,7 @@ RSDraggableCanvasInteraction class >> right [
 { #category : #mouse }
 RSDraggableCanvasInteraction >> all [
 	"Any mouse button can be used to drag and drop the view"
-	mouseEvent := RSMouseDragStart.
+	mouseEvent := RSMouseDragStartEvent.
 ]
 
 { #category : #computing }
@@ -67,12 +67,12 @@ RSDraggableCanvasInteraction >> initialize [
 
 { #category : #mouse }
 RSDraggableCanvasInteraction >> left [
-	mouseEvent := RSMouseLeftDragStart
+	mouseEvent := RSMouseLeftDragStartEvent
 ]
 
 { #category : #mouse }
 RSDraggableCanvasInteraction >> middle [
-	mouseEvent := RSMouseMiddleDragStart
+	mouseEvent := RSMouseMiddleDragStartEvent
 ]
 
 { #category : #events }
@@ -138,8 +138,8 @@ RSDraggableCanvasInteraction >> mouseStart: evt [
 RSDraggableCanvasInteraction >> onShape: aCanvas [
 	aCanvas 
 		when: self mouseEvent send: #mouseStart: to: self;
-		when: RSMouseDragging send: #mouseMove: to: self;
-		when: RSMouseDragEnd send: #mouseEnd: to: self.
+		when: RSMouseDraggingEvent send: #mouseMove: to: self;
+		when: RSMouseDragEndEvent send: #mouseEnd: to: self.
 ]
 
 { #category : #rendering }
@@ -149,5 +149,5 @@ RSDraggableCanvasInteraction >> renderLegendOn: lb [
 
 { #category : #mouse }
 RSDraggableCanvasInteraction >> right [
-	mouseEvent := RSMouseRightDragStart.
+	mouseEvent := RSMouseRightDragStartEvent.
 ]

--- a/src/Roassal3-Interaction/RSElasticBox.class.st
+++ b/src/Roassal3-Interaction/RSElasticBox.class.st
@@ -151,7 +151,7 @@ RSElasticBox >> initialize [
 
 { #category : #public }
 RSElasticBox >> leftRight [
-	events := { RSMouseLeftDragStart. RSMouseRightDragStart }.
+	events := { RSMouseLeftDragStartEvent. RSMouseRightDragStartEvent }.
 ]
 
 { #category : #public }
@@ -167,8 +167,8 @@ RSElasticBox >> onShape: aCanvas [
 	aCanvas
 		when: self dragStartEvent send: #enableDrag: to: self;
 		when: self boxStartEvent send: #disableDrag: to: self;
-		when: RSMouseDragging send: #processDrag: to: self;
-		when: RSMouseDragEnd send: #processDragEnd: to: self
+		when: RSMouseDraggingEvent send: #processDrag: to: self;
+		when: RSMouseDragEndEvent send: #processDragEnd: to: self
 ]
 
 { #category : #announcer }
@@ -192,7 +192,7 @@ RSElasticBox >> processDragEnd: event [
 
 { #category : #public }
 RSElasticBox >> rightLeft [
-	events := { RSMouseRightDragStart. RSMouseLeftDragStart }.
+	events := { RSMouseRightDragStartEvent. RSMouseLeftDragStartEvent }.
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Interaction/RSHighlightable.class.st
+++ b/src/Roassal3-Interaction/RSHighlightable.class.st
@@ -507,8 +507,8 @@ RSHighlightable >> lowColor: lowColor highColor: highColor [
 { #category : #hooks }
 RSHighlightable >> onShape: aShape [
 	aShape
-		when: RSMouseEnter do: [ :evt | self doHighlight: evt shape. evt signalUpdate ];
-		when: RSMouseLeave do: [ :evt | self doUnhighlight: evt shape. evt signalUpdate ]
+		when: RSMouseEnterEvent do: [ :evt | self doHighlight: evt shape. evt signalUpdate ];
+		when: RSMouseLeaveEvent do: [ :evt | self doUnhighlight: evt shape. evt signalUpdate ]
 ]
 
 { #category : #'public - hooks' }

--- a/src/Roassal3-Interaction/RSKeyNavigationCanvasInteraction.class.st
+++ b/src/Roassal3-Interaction/RSKeyNavigationCanvasInteraction.class.st
@@ -30,8 +30,8 @@ RSKeyNavigationCanvasInteraction >> initialize [
 { #category : #hooks }
 RSKeyNavigationCanvasInteraction >> onShape: aCanvas [
 	aCanvas 
-		when: RSKeyDown do: [ :evt | self processKeyDown: evt ];
-		when: RSKeyUp do: [ :evt | self processKeyUp: evt ].
+		when: RSKeyDownEvent do: [ :evt | self processKeyDown: evt ];
+		when: RSKeyUpEvent do: [ :evt | self processKeyUp: evt ].
 ]
 
 { #category : #events }

--- a/src/Roassal3-Interaction/RSLabeled.class.st
+++ b/src/Roassal3-Interaction/RSLabeled.class.st
@@ -107,8 +107,8 @@ RSLabeled >> createLabel: aShape [
 		targetLabel color: c.
 		label signalUpdate ].
 	aShape 
-		when: RSMouseEnter do: [ set value: color ];
-		when: RSMouseLeave do: [ set value: lowColor ];
+		when: RSMouseEnterEvent do: [ set value: color ];
+		when: RSMouseLeaveEvent do: [ set value: lowColor ];
 		when: RSShapeRemovedEvent do: [ label remove ].
 	^ label
 ]

--- a/src/Roassal3-Interaction/RSMenuActivable.class.st
+++ b/src/Roassal3-Interaction/RSMenuActivable.class.st
@@ -34,7 +34,7 @@ RSMenuActivable >> menuDo: block [
 RSMenuActivable >> onShape: aShape [
 	"No need to do anything if empty"
 	menuBlock isNil ifTrue: [ ^ self ].
-	aShape when: RSMouseRightClick do: [ :evt | 
+	aShape when: RSMouseRightClickEvent do: [ :evt | 
 		| menu |
 		menu := MenuMorph new.
 		menuBlock value: menu value: evt shape.

--- a/src/Roassal3-Interaction/RSRotated.class.st
+++ b/src/Roassal3-Interaction/RSRotated.class.st
@@ -49,7 +49,7 @@ RSRotated >> initialize [
 RSRotated >> onShape: aShape [
 	targetShape := aShape.
 	aShape parent
-		when: RSMouseLeftDragStart do: [ :evt|  self dragStart: evt ];
-		when: RSMouseDragging do: [ :evt | self dragging: evt ];
-		when: RSMouseDragEnd do: [ :evt | self dragEnd: evt ].
+		when: RSMouseLeftDragStartEvent do: [ :evt|  self dragStart: evt ];
+		when: RSMouseDraggingEvent do: [ :evt | self dragging: evt ];
+		when: RSMouseDragEndEvent do: [ :evt | self dragEnd: evt ].
 ]

--- a/src/Roassal3-Interaction/RSScrollBarsCanvas.class.st
+++ b/src/Roassal3-Interaction/RSScrollBarsCanvas.class.st
@@ -81,15 +81,15 @@ RSScrollBarsCanvas >> initializeShape [
 		size: 10;
 		noPaint;
 		isFixed: true;
-		when: RSMouseDragging do: [:evt| self moveScroll: evt ];
-		when: RSMouseEnter do: [ :evt| | shape |
+		when: RSMouseDraggingEvent do: [:evt| self moveScroll: evt ];
+		when: RSMouseEnterEvent do: [ :evt| | shape |
 			self updateScrollbars.
 			shape := evt shape.
 			shape color isTransparent 
 				ifFalse: [ shape color: (self scrollColor alpha: 1) ].
 			animation stop.
 			hideAnimation stop ];
-		when: RSMouseLeave do: [ :evt| | shape |
+		when: RSMouseLeaveEvent do: [ :evt| | shape |
 			shape := evt shape.
 			shape color isTransparent 
 				ifFalse: [ shape color: self scrollColor ].

--- a/src/Roassal3-Interaction/RSSearchInCanvas.class.st
+++ b/src/Roassal3-Interaction/RSSearchInCanvas.class.st
@@ -116,7 +116,7 @@ RSSearchInCanvas >> click: evt [
 	shadow := (shapes at: index) propertyAt: #shadow.
 	shadow color: label color.
 	
-	index := evt class == RSMouseLeftClick 
+	index := evt class == RSMouseLeftClickEvent 
 		ifTrue: [ index % shapes size + 1]
 		ifFalse: [ index - 1 ].
 	index = 0 ifTrue: [ index := shapes size ].
@@ -247,7 +247,7 @@ RSSearchInCanvas >> obtainRegExpToHighlight [
 { #category : #public }
 RSSearchInCanvas >> onShape: aCanvas [
 	aCanvas 
-		when: RSKeyUp do: [ :evt | self processKeyUp: evt ]
+		when: RSKeyUpEvent do: [ :evt | self processKeyUp: evt ]
 ]
 
 { #category : #'private - events' }
@@ -341,7 +341,7 @@ RSSearchInCanvas >> searchForShapes: regExp [
 	
 	lbl fontSize: 14.
 	lbl @ RSPopup; @ highlightableLabels.
-	lbl when: RSMouseClick send: #click: to: self.
+	lbl when: RSMouseClickEvent send: #click: to: self.
 	lbl color: self colorToUseToHighlight.
 	canvas add: lbl.
 	lbl setAsFixed.

--- a/src/Roassal3-Interaction/RSTransformable.class.st
+++ b/src/Roassal3-Interaction/RSTransformable.class.st
@@ -72,9 +72,9 @@ RSTransformable >> createHandleFor: association [
 		draggable;
 		yourself.
 	handle announcer
-		when: RSMouseEnter send: #showCursor: to: self;
-		when: RSMouseLeave send: #removeCursor to: self;
-		when: RSMouseDragStart send: #saveCurrentShapeState to: self;
+		when: RSMouseEnterEvent send: #showCursor: to: self;
+		when: RSMouseLeaveEvent send: #removeCursor to: self;
+		when: RSMouseDragStartEvent send: #saveCurrentShapeState to: self;
 		when: RSPositionChangedEvent send: #updateCurrentShape: to: self.
 	^ handle
 ]
@@ -139,9 +139,9 @@ RSTransformable >> leftCenter: position rectangle: rectangle [
 RSTransformable >> onShape: aShape [
 	aShape isNode ifFalse: [ ^ self ].
 	aShape announcer
-		when: RSMouseLeftClick send: #showHandles: to: self;
-		when: RSMouseDragStart send: #disableHandles: to: self;
-		when: RSMouseDragEnd send: #enableHandles: to: self.
+		when: RSMouseLeftClickEvent send: #showHandles: to: self;
+		when: RSMouseDragStartEvent send: #disableHandles: to: self;
+		when: RSMouseDragEndEvent send: #enableHandles: to: self.
 ]
 
 { #category : #private }
@@ -150,7 +150,7 @@ RSTransformable >> registerCanvasEventsIfNecessary: evt [
 	canvas := evt canvas.
 	(canvas hasInteraction: self class) ifTrue: [ ^ self ].
 	canvas announcer
-		when: RSMouseClick 
+		when: RSMouseClickEvent 
 		send: #removeHandles:
 		to: self
 ]
@@ -186,8 +186,8 @@ RSTransformable >> rotationShape [
 	^ RSBitmap new
 		form: (self iconNamed: #smallUpdate);
 		scaleBy: 2;
-		when: RSMouseEnter send: #showRotationCursor to: self;
-		when: RSMouseLeave send: #removeCursor to: self;
+		when: RSMouseEnterEvent send: #showRotationCursor to: self;
+		when: RSMouseLeaveEvent send: #removeCursor to: self;
 		yourself
 ]
 

--- a/src/Roassal3-Interaction/RSZoomToFitCanvas.class.st
+++ b/src/Roassal3-Interaction/RSZoomToFitCanvas.class.st
@@ -59,7 +59,7 @@ RSZoomToFitCanvas >> cameraFor: aCanvas [
 
 { #category : #hooks }
 RSZoomToFitCanvas >> onShape: aCanvas [
-	aCanvas when: RSKeyUp do: [ :evt | self processKeyUp: evt ].
+	aCanvas when: RSKeyUpEvent do: [ :evt | self processKeyUp: evt ].
 	aCanvas when: RSExtentChangedEvent do: [ self zoomToFitIfNecessary: aCanvas ].
 	aCanvas camera: (self cameraFor: aCanvas). 
 	self configuration shouldZoomToFitOnStart ifFalse: [ ^ self ].

--- a/src/Roassal3-Layouts/RSDraggableForce.class.st
+++ b/src/Roassal3-Layouts/RSDraggableForce.class.st
@@ -25,11 +25,11 @@ RSDraggableForce >> onShape: aShape [
 
 	aShape removeInteractionIfPresent: RSDraggable.
 	aShape 
-		when: RSMouseDragStart do: [ :evt | 
+		when: RSMouseDragStartEvent do: [ :evt | 
 			layout
 				mockElementAt: evt shape
 				ifPresent: [ :mock | mock isFixed: true ] ];
-		when: RSMouseDragging do: [ :evt |
+		when: RSMouseDraggingEvent do: [ :evt |
 			| d |
 			d := evt shape parent camera distanceFromPixelToSpace: evt step.
 			evt shape translateBy: d.
@@ -37,7 +37,7 @@ RSDraggableForce >> onShape: aShape [
 				mockElementAt: evt shape
 				ifPresent: [ :mock | mock fixPosition: evt shape position ].
 			evt shape signalUpdate ];
-		when: RSMouseDragEnd do:[:evt | 
+		when: RSMouseDragEndEvent do:[:evt | 
 			layout
 				mockElementAt: evt shape
 				ifPresent: [ :mock | mock isFixed: false ] ].

--- a/src/Roassal3-Layouts/RSForceLayoutInSpaces.class.st
+++ b/src/Roassal3-Layouts/RSForceLayoutInSpaces.class.st
@@ -120,7 +120,7 @@ RSForceLayoutInSpaces >> fill: space with: aCollection [
 		start.
 	aCollection do: [ :s | s propertyAt: #layout put: layout ].
 	aCollection @ (RSDraggableForce new layout: layout).
-	aCollection do:[ :s | s when: RSMouseDragEnd send: #dragEnd: to: self ]
+	aCollection do:[ :s | s when: RSMouseDragEndEvent send: #dragEnd: to: self ]
 
 ]
 

--- a/src/Roassal3-Layouts/RSForceLayoutStepping.class.st
+++ b/src/Roassal3-Layouts/RSForceLayoutStepping.class.st
@@ -16,13 +16,13 @@ Class {
 RSForceLayoutStepping >> addEventsTo: shape [
 	| mock |
 	shape 
-		when: RSMouseDragStart do: [ :evt | 
+		when: RSMouseDragStartEvent do: [ :evt | 
 			mock := layout mockElementAt: evt shape.
 			mock isFixed: true.
 			self startForceAnimation: evt canvas ];
-		when: RSMouseDragging do: [ :evt |
+		when: RSMouseDraggingEvent do: [ :evt |
 			mock fixPosition: evt shape position ];
-		when: RSMouseDragEnd do:[:evt | 
+		when: RSMouseDragEndEvent do:[:evt | 
 			mock isFixed: false.
 			mock := nil.
 			self startSimpleAnimation: evt canvas ].

--- a/src/Roassal3-Mondrian/RSAbstractConnection.class.st
+++ b/src/Roassal3-Mondrian/RSAbstractConnection.class.st
@@ -93,7 +93,7 @@ RSAbstractConnection >> output: oneArgBlock [
 
 { #category : #'as yet unclassified' }
 RSAbstractConnection >> prepareInputCanvas [
-	inputCanvas nodes when: RSMouseClick do: [ :event |
+	inputCanvas nodes when: RSMouseClickEvent do: [ :event |
 		self clickOnShape: event shape ].
 	
 	inputCanvas nodes @ RSSelectionPresentation

--- a/src/Roassal3-Mondrian/RSChannel.class.st
+++ b/src/Roassal3-Mondrian/RSChannel.class.st
@@ -18,17 +18,17 @@ Class {
 { #category : #public }
 RSChannel >> build [
 
-	inputGroup when: RSMouseEnter do: [ :evt | 
+	inputGroup when: RSMouseEnterEvent do: [ :evt | 
 		self doHighlight.
 		evt signalUpdate ].
 	inputGroup @ (RSHighlightable new highlightColor: self color).
 
-	inputGroup when: RSMouseLeave do: [ :evt | 
+	inputGroup when: RSMouseLeaveEvent do: [ :evt | 
 		self doUnhighlight.
 		evt signalUpdate ].
 
 	isClickable ifFalse: [ ^ self ].
-	inputGroup when: RSMouseClick do: [ :evt | 
+	inputGroup when: RSMouseClickEvent do: [ :evt | 
 		isClicked
 			ifTrue: [ self unmark: evt shape. 
 						self doUnmark. 	

--- a/src/Roassal3-Mondrian/RSChannelTest.class.st
+++ b/src/Roassal3-Mondrian/RSChannelTest.class.st
@@ -71,15 +71,15 @@ RSChannelTest >> testBasic [
 	"-------"
 
 	self assert: mondrianNodes first color equals: Color gray.
-	mondrianNodes first announce: RSMouseEnter.
+	mondrianNodes first announce: RSMouseEnterEvent.
 	self assert: mondrianNodes first color equals: Color gray.
 	
-	oddLabel announce: RSMouseEnter.
+	oddLabel announce: RSMouseEnterEvent.
 	self assert: mondrianNodes first color equals: Color blue.
-	oddLabel announce: RSMouseLeave.
+	oddLabel announce: RSMouseLeaveEvent.
 	self assert: mondrianNodes first color equals: Color gray.
 
-	oddLabel announce: RSMouseClick.
+	oddLabel announce: RSMouseClickEvent.
 ]
 
 { #category : #tests }
@@ -133,19 +133,19 @@ RSChannelTest >> testBasicWithCallbacks [
 	"-------"
 
 	self assert: mondrianNodes first color equals: Color gray.
-	mondrianNodes first announce: RSMouseEnter.
+	mondrianNodes first announce: RSMouseEnterEvent.
 	self assert: mondrianNodes first color equals: Color gray.
 
 	
-	oddLabel announce: RSMouseEnter.
+	oddLabel announce: RSMouseEnterEvent.
 	self assert: mondrianNodes first color equals: Color blue.
-	oddLabel announce: RSMouseLeave.
+	oddLabel announce: RSMouseLeaveEvent.
 	self assert: mondrianNodes first color equals: Color gray.
 
 	self assert: value isEmpty.
-	oddLabel announce: RSMouseClick.
+	oddLabel announce: RSMouseClickEvent.
 	self assert: value asArray equals: #('ONOdd').
-	oddLabel announce: RSMouseClick.
+	oddLabel announce: RSMouseClickEvent.
 	self assert: value asArray equals: #('ONOdd' 'OFFOdd').
 ]
 
@@ -182,7 +182,7 @@ RSChannelTest >> testLocationsOfUnderlines [
 	self assert: (channel1 getAllMarksFrom: box) isEmpty.
 	self assert: box properties size equals: 0.
 
-	lbl1 announce: RSMouseClick.
+	lbl1 announce: RSMouseClickEvent.
 	self assert: c numberOfShapes equals: 5.
 
 	self assert: (channel1 getAllMarksFrom: box) size equals: 1.
@@ -192,7 +192,7 @@ RSChannelTest >> testLocationsOfUnderlines [
 	self assert: markBlue color equals: Color blue.
 	self assert: (channel1 getAllMarksFrom: box) anyOne equals: markBlue.
 
-	lbl2 announce: RSMouseClick.
+	lbl2 announce: RSMouseClickEvent.
 	self assert: c numberOfShapes equals: 7.
 	self assert: box properties size equals: 2.
 	markRed := (box properties values copyWithout: markBlue) anyOne.

--- a/src/Roassal3-Mondrian/RSConnectionTest.class.st
+++ b/src/Roassal3-Mondrian/RSConnectionTest.class.st
@@ -22,13 +22,13 @@ RSConnectionTest >> testBasic [
 	].
 	
 	self assert: connection numberOfCreatedCanvases equals: 0.
-	(c canvas shapeFromModel: 1) announce: RSMouseClick.
+	(c canvas shapeFromModel: 1) announce: RSMouseClickEvent.
 	self assert: connection numberOfCreatedCanvases equals: 1.
 	
-	(c canvas shapeFromModel: 1) announce: RSMouseClick.
+	(c canvas shapeFromModel: 1) announce: RSMouseClickEvent.
 	self assert: connection numberOfCreatedCanvases equals: 2.
 	
-	(c canvas shapeFromModel: 91) announce: RSMouseClick.
+	(c canvas shapeFromModel: 91) announce: RSMouseClickEvent.
 	self assert: connection numberOfCreatedCanvases equals: 3.
 	
 	connection deleteAllWindows.

--- a/src/Roassal3-Mondrian/RSFlowCanvas.class.st
+++ b/src/Roassal3-Mondrian/RSFlowCanvas.class.st
@@ -85,7 +85,7 @@ RSFlowCanvas >> setOnCanvas: aCanvas [
 	self assert: [ aCanvas class == RSCanvas ] description: 'Must provide a canvas'.
 	canvas := aCanvas.
 	relevantShapes := (aCanvas deepNodes select: [ :s | s model notNil ]) asGroup.
-	relevantShapes when: RSMouseClick do: [ :evt |
+	relevantShapes when: RSMouseClickEvent do: [ :evt |
 		self clickOnModel: evt shape model ].
 	
 
@@ -101,7 +101,7 @@ RSFlowCanvas >> updateBreadcrumbs [
 	   lbl := RSLabel text: obj asString, '/ ' model: obj.
 		breadcrumbsLabels add: lbl.
 		lbl @ RSHighlightable red. 
-		lbl when: RSMouseClick do: [ :evt | 
+		lbl when: RSMouseClickEvent do: [ :evt | 
 			| i |
 			i := breadcrumbsLabels indexOf: lbl.
 			breadcrumbs := breadcrumbs first: i - 1.

--- a/src/Roassal3-Mondrian/RSFlowCanvasTest.class.st
+++ b/src/Roassal3-Mondrian/RSFlowCanvasTest.class.st
@@ -57,7 +57,7 @@ RSFlowCanvasTest >> testNestedNodes [
 
 	self assert: nb equals: 0.
 	
-	box announce: RSMouseClick.
+	box announce: RSMouseClickEvent.
 	self assert: nb equals: 10.
 ]
 

--- a/src/Roassal3-Pie-Examples/RSPieExamples.class.st
+++ b/src/Roassal3-Pie-Examples/RSPieExamples.class.st
@@ -648,14 +648,14 @@ RSPieExamples >> example19Buttons [
 			position: 50 asPoint;
 			shiftAngles: 45/ -2;
 			setAsFixed;
-			when: RSMouseEnter do: [ 
+			when: RSMouseEnterEvent do: [ 
 				move := shape model.
 				canvas newAnimation 
 					duration: 1 second;
 					easing: RSEasing backOut;
 					from: 40; to: 50;
 					on: shape shape set: #externalRadius:. ];
-			when: RSMouseLeave do: [ 
+			when: RSMouseLeaveEvent do: [ 
 				move := 0@0.
 				canvas newAnimation 
 					duration: 1 second;
@@ -697,7 +697,7 @@ RSPieExamples >> example20AddingRemoving [
 	pie
 		sliceColor: [:slice | color scale: slice model ];
 		build.
-	pieClick := [ pie shapes when: RSMouseClick do: [ :evt |
+	pieClick := [ pie shapes when: RSMouseClickEvent do: [ :evt |
 		objects remove: evt shape model.
 		removed add: evt shape model.
 		update value.
@@ -744,7 +744,7 @@ RSPieExamples >> example20AddingRemoving [
 				model: m;
 				text: m;
 				position: index * (0@30) +  (300@0);
-				when: RSMouseClick do: [ :evt | | model |
+				when: RSMouseClickEvent do: [ :evt | | model |
 					model := evt shape model.
 					objects add: model.
 					removed remove: model.
@@ -802,7 +802,7 @@ RSPieExamples >> example22RotatedAnimation [
 		innerRadius: 70;
 		segmentSpacing: 0.5;
 		externalRadius: 220;
-		when: RSMouseClick do: [ [ animation toggle ] ].
+		when: RSMouseClickEvent do: [ [ animation toggle ] ].
 	pieLabel := RSPieLabeled new.
 	pieLabel labelText: #name.
 	pie build.
@@ -866,7 +866,7 @@ RSPieExamples >> example23RotatedAnimation [
 			obj basename, String cr,
 			(directorySize value: obj) humanReadableSIByteSize ]);
 		@ pieLabel;
-		when: RSMouseClick do: [ animation toggle ].
+		when: RSMouseClickEvent do: [ animation toggle ].
 	
 	lines := pie shapes collect: [:s | RSPolyline new
 		border: (RSBorder new dashArray: #(3));

--- a/src/Roassal3-Pie/RSRotatedPieLabelDecorator.class.st
+++ b/src/Roassal3-Pie/RSRotatedPieLabelDecorator.class.st
@@ -47,7 +47,7 @@ RSRotatedPieLabelDecorator >> render [
 	container
 		addAll: lines;
 		addAll: labels.
-	builder shapes when: RSMouseClick do: [ animation toggle ].
+	builder shapes when: RSMouseClickEvent do: [ animation toggle ].
 	self createAnimation.
 	self stepShapes: 0
 ]

--- a/src/Roassal3-SVG-Examples/RSAnimationExamples.extension.st
+++ b/src/Roassal3-SVG-Examples/RSAnimationExamples.extension.st
@@ -49,7 +49,7 @@ RSAnimationExamples >> example04Phyco [
 			canvas add: line.
 		].
 	].
-	canvas when: RSMouseClick do: [ :evt | canvas edges inspect ].
+	canvas when: RSMouseClickEvent do: [ :evt | canvas edges inspect ].
 	canvas newAnimation repeat onStepDo: [ :t |
 		update value.
 		theta := theta + 0.0523 ].

--- a/src/Roassal3-SVG-Examples/RSBasicShapeExamples.extension.st
+++ b/src/Roassal3-SVG-Examples/RSBasicShapeExamples.extension.st
@@ -51,7 +51,7 @@ RSBasicShapeExamples >> example16BasicLinePath [
 			endPoint: b2 position.
 		evt shape translateBy: evt step.
 		evt signalUpdate ].
-	b1 when: RSMouseDragging do: translate.
-	b2 when: RSMouseDragging do: translate.
+	b1 when: RSMouseDraggingEvent do: translate.
+	b2 when: RSMouseDraggingEvent do: translate.
 	^ c
 ]

--- a/src/Roassal3-Shapes-Tests/RSCanvasTest.class.st
+++ b/src/Roassal3-Shapes-Tests/RSCanvasTest.class.st
@@ -123,7 +123,7 @@ RSCanvasTest >> testEncompassingRectangle [
 RSCanvasTest >> testEvent [ 
 	| box |
 	box := RSBox new.
-	box when: RSMouseClick do: [ :evt |  ]
+	box when: RSMouseClickEvent do: [ :evt |  ]
 ]
 
 { #category : #tests }
@@ -154,11 +154,11 @@ RSCanvasTest >> testEventKnowsItsCanvas02 [
 RSCanvasTest >> testLowLevelEvent [
 	| box |
 	box := RSBox new size: 30.
-	box when: RSMouseDragging do: [ :evt | box ].
+	box when: RSMouseDraggingEvent do: [ :evt | box ].
 	canvas addShape: box.
 	self assert: canvas extent equals: 500 asPoint.
 	self
-		assert: (canvas shapeWithAction: RSMouseDragging forPositionInPixels: 250 @ 250)
+		assert: (canvas shapeWithAction: RSMouseDraggingEvent forPositionInPixels: 250 @ 250)
 		identicalTo: box
 ]
 

--- a/src/Roassal3-Spec-Examples/RSColorPaletteChooser.class.st
+++ b/src/Roassal3-Spec-Examples/RSColorPaletteChooser.class.st
@@ -41,7 +41,7 @@ RSColorPaletteChooser >> boxColorFor: color [
 	^ RSComposite new
 		  @ boxOver;
 		  model: color;
-		  when: RSMouseClick do: [ :evt | self copyToClipboard: evt shape model ];
+		  when: RSMouseClickEvent do: [ :evt | self copyToClipboard: evt shape model ];
 		  shapes: { box. label};
 		  yourself
 ]
@@ -75,7 +75,7 @@ RSColorPaletteChooser >> buttonFor: m [
 		  model: m;
 		  shapes: { box. label };
 		  @ overHighlight;
-		  when: RSMouseClick
+		  when: RSMouseClickEvent
 		  do: [ :evt | self renderColorPalettesFor: evt shape ];
 		  yourself
 ]
@@ -187,7 +187,7 @@ RSColorPaletteChooser >> paletteFor: method [
 		shapes: shapes;
 		padding: 10;
 		withBorder;
-		when: RSMouseClick 
+		when: RSMouseClickEvent 
 			do: [ :evt | self copyToClipboard: evt shape model].
 		
 ]

--- a/src/Roassal3-Spec-Morphic/SpMorphicRoassalAdapter.class.st
+++ b/src/Roassal3-Spec-Morphic/SpMorphicRoassalAdapter.class.st
@@ -50,7 +50,7 @@ SpMorphicRoassalAdapter >> basicApplyScript [
 	self model script value: canvas.
 	self model canvas: canvas.
 	self widgetDo: #startStepping.
-	canvas when: RSMouseEnter do: [ widget takeKeyboardFocus ].
+	canvas when: RSMouseEnterEvent do: [ widget takeKeyboardFocus ].
 ]
 
 { #category : #factory }

--- a/src/Roassal3-Spec-Obsolete/Sp1MorphicAdapter.class.st
+++ b/src/Roassal3-Spec-Obsolete/Sp1MorphicAdapter.class.st
@@ -36,7 +36,7 @@ Sp1MorphicAdapter >> basicApplyScript [
 	self model script value: canvas.
 	self widgetDo: #startStepping.
 	
-	canvas when: RSMouseEnter do: [ widget takeKeyboardFocus].
+	canvas when: RSMouseEnterEvent do: [ widget takeKeyboardFocus].
 ]
 
 { #category : #initialization }

--- a/src/Roassal3-Sunburst-Examples/RSSunburstExamples.class.st
+++ b/src/Roassal3-Sunburst-Examples/RSSunburstExamples.class.st
@@ -140,14 +140,14 @@ RSSunburstExamples >> example07FadeInteraction [
 	label isFixed: true.
 
 	 sb shapes 
-		when: RSMouseEnter do: [ :evt | 
+		when: RSMouseEnterEvent do: [ :evt | 
 			| path |
 			path := (interaction pathFor: evt shape) reverse.
 			path := String streamContents: [:s | 
 				path do: [ :node | s << node model asString ] separatedBy: [ s << '>>' ] ].
 			label text: path; signalUpdate.
 			label position: label extent / 2 ];
-		when: RSMouseLeave do: [ :evt |
+		when: RSMouseLeaveEvent do: [ :evt |
 			label text: '' ].
 	sb shapes @ interaction.
 	sb canvas add: label.
@@ -207,11 +207,11 @@ RSSunburstExamples >> example08SunburstExplorer [
 		
 		newShapes := sb shapes.
 		first := newShapes first.
-		first when: RSMouseClick do: [ :evt | | cls |
+		first when: RSMouseClickEvent do: [ :evt | | cls |
 			cls := evt shape model superclass.
 			cls = Object ifFalse: [ newData value: cls ] ].
 		(newShapes allButFirst reject: #isSLeaf)
-			when: RSMouseClick do: [ :evt | newData value: evt shape model ].
+			when: RSMouseClickEvent do: [ :evt | newData value: evt shape model ].
 		
 		newShapes size < lastShapes size ifTrue: [ 
 			newShapes do: [:new | | old |

--- a/src/Roassal3-Sunburst/RSSunburstFadeInteraction.class.st
+++ b/src/Roassal3-Sunburst/RSSunburstFadeInteraction.class.st
@@ -38,11 +38,11 @@ RSSunburstFadeInteraction >> initialize [
 { #category : #initialization }
 RSSunburstFadeInteraction >> onShape: aShape [
 	aShape
-		when: RSMouseEnter do: [ :evt | 
+		when: RSMouseEnterEvent do: [ :evt | 
 			still := true.
 			self doHighlight: evt shape.
 			evt signalUpdate ];
-		when: RSMouseLeave do: [ :evt | 
+		when: RSMouseLeaveEvent do: [ :evt | 
 			still := false.
 			evt canvas newAnimation
 				duration: 300 milliSeconds; 

--- a/src/Roassal3-UML-Tests/RSUMLClassBuilderTest.class.st
+++ b/src/Roassal3-UML-Tests/RSUMLClassBuilderTest.class.st
@@ -23,7 +23,7 @@ RSUMLClassBuilderTest >> testBasic [
 RSUMLClassBuilderTest >> testJustClassName [
 	| builder shape  |
 	builder := self classToTest new.
-	builder classes: {RSMouseMove}.
+	builder classes: {RSMouseMoveEvent}.
 	builder build.
 	shape := builder shapes first.
 	self assert: shape shapes size equals: 2.
@@ -31,7 +31,7 @@ RSUMLClassBuilderTest >> testJustClassName [
 	self assert: shape shapes second class equals: RSComposite.
 	
 	builder := self classToTest new.
-	builder classes: {RSMouseMove}.
+	builder classes: {RSMouseMoveEvent}.
 	builder renderer: RSTorchUMLClassRenderer new.
 	builder build.
 	shape := builder shapes first.

--- a/src/Roassal3-UML/RSAbstractUMLCalypso.class.st
+++ b/src/Roassal3-UML/RSAbstractUMLCalypso.class.st
@@ -13,8 +13,8 @@ Class {
 { #category : #building }
 RSAbstractUMLCalypso >> addClassInteractions: builder [
 	builder canvas nodes 
-		when: RSMouseDoubleClick do: [ :evt | evt shape model browse ];
-		when: RSMouseRightClick do: [ :evt | 
+		when: RSMouseDoubleClickEvent do: [ :evt | evt shape model browse ];
+		when: RSMouseRightClickEvent do: [ :evt | 
 			| menu newContext tool |
 			tool := ClyFullBrowserMorph on: ClyNavigationEnvironment currentImage.
 			tool 
@@ -49,7 +49,7 @@ RSAbstractUMLCalypso >> build [
 	morph := canvas createMorph.
 	morph onAnnouncement: MorphDeleted 
 		do: [ self containerTab owner ifNotNil: [ self containerTab delete]].
-	canvas when: RSMouseEnter do: [ morph takeKeyboardFocus].
+	canvas when: RSMouseEnterEvent do: [ morph takeKeyboardFocus].
 	self addMorph: morph fullFrame: LayoutFrame identity
 ]
 

--- a/src/Roassal3-UML/RSBaselineCalypso.class.st
+++ b/src/Roassal3-UML/RSBaselineCalypso.class.st
@@ -131,7 +131,7 @@ RSBaselineCalypso >> buildMenuOn: canvas [
 			text: name;
 			isFixed: true;
 			@ self highlightableMenu;
-			when: RSMouseClick send: action asSymbol to: self;
+			when: RSMouseClickEvent send: action asSymbol to: self;
 			yourself.
 		label when: RSExtentChangedEvent do: [ :evt |
 			self layoutMenu: menus.
@@ -282,7 +282,7 @@ RSBaselineCalypso >> shapeFor: assoc [
 		model: assoc key;
 		yourself.
 	shape
-		when: RSMouseDoubleClick
+		when: RSMouseDoubleClickEvent
 		do: [ :evt | (self class environment at: evt shape model) browse ].
 	assoc value ifNil: [ 
 		shape @ self notLoadedPopup.

--- a/src/Roassal3-UML/RSShape.extension.st
+++ b/src/Roassal3-UML/RSShape.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #RSShape }
 
 { #category : #'*Roassal3-UML' }
 RSShape >> browseable [
-	self when: RSMouseClick do: [ self model browse  ].
+	self when: RSMouseClickEvent do: [ self model browse  ].
 ]

--- a/src/Roassal3/RSAbstractMouseClickEvent.class.st
+++ b/src/Roassal3/RSAbstractMouseClickEvent.class.st
@@ -2,7 +2,7 @@
 abstract for mouse click events
 "
 Class {
-	#name : #RSAbstractMouseClick,
+	#name : #RSAbstractMouseClickEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSAthensMorph.class.st
+++ b/src/Roassal3/RSAthensMorph.class.st
@@ -126,7 +126,7 @@ RSAthensMorph >> drawShapes [
 { #category : #'event-processed' }
 RSAthensMorph >> eventKeyDown: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSKeyDown from: aMorphicEvent.
+	trEvent := self eventOfClass: RSKeyDownEvent from: aMorphicEvent.
 	trEvent
 		position: (roassalCanvas camera fromPixelToSpace: trEvent position);
 		keyValue: aMorphicEvent keyValue;
@@ -138,7 +138,7 @@ RSAthensMorph >> eventKeyDown: aMorphicEvent [
 { #category : #'event-processed' }
 RSAthensMorph >> eventKeyUp: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSKeyUp from: aMorphicEvent.
+	trEvent := self eventOfClass: RSKeyUpEvent from: aMorphicEvent.
 	trEvent
 		position: (roassalCanvas camera fromPixelToSpace: trEvent position);
 		keyValue: aMorphicEvent keyValue;
@@ -150,9 +150,9 @@ RSAthensMorph >> eventKeyUp: aMorphicEvent [
 RSAthensMorph >> eventMouseClick: aMorphicEvent [
 	| trEvent |
 	trEvent := self
-		mouseEventOfClass: RSMouseClick
-		ifLeftButton: RSMouseLeftClick
-		ifRightButton: RSMouseRightClick
+		mouseEventOfClass: RSMouseClickEvent
+		ifLeftButton: RSMouseLeftClickEvent
+		ifRightButton: RSMouseRightClickEvent
 		from: aMorphicEvent.
 	trEvent position: (roassalCanvas camera fromPixelToSpace: trEvent position).
 	trEvent shape announce: trEvent.
@@ -162,9 +162,9 @@ RSAthensMorph >> eventMouseClick: aMorphicEvent [
 RSAthensMorph >> eventMouseDoubleClick: aMorphicEvent [
 	| trEvent |
 	trEvent := self
-		mouseEventOfClass: RSMouseDoubleClick
-		ifLeftButton: RSMouseDoubleLeftClick
-		ifRightButton: RSMouseDoubleRightClick
+		mouseEventOfClass: RSMouseDoubleClickEvent
+		ifLeftButton: RSMouseDoubleLeftClickEvent
+		ifRightButton: RSMouseDoubleRightClickEvent
 		from: aMorphicEvent.
 	trEvent position: (roassalCanvas camera fromPixelToSpace: trEvent position).
 	trEvent shape announce: trEvent.
@@ -173,7 +173,7 @@ RSAthensMorph >> eventMouseDoubleClick: aMorphicEvent [
 { #category : #'event-processed' }
 RSAthensMorph >> eventMouseDragEnd: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSMouseDragEnd from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseDragEndEvent from: aMorphicEvent.
 	trEvent shape: shapeBeingPointed.
 	shapeBeingPointed announce: trEvent.
 	
@@ -185,14 +185,14 @@ RSAthensMorph >> eventMouseDragStart: aMorphicEvent [
 	| trEvent trEventClass |
 	eventBeginingDragging := aMorphicEvent copy.
 	
-	trEventClass := RSMouseDragStart.
+	trEventClass := RSMouseDragStartEvent.
 	aMorphicEvent redButtonChanged
-		ifTrue: [ trEventClass := RSMouseLeftDragStart ].
+		ifTrue: [ trEventClass := RSMouseLeftDragStartEvent ].
 	aMorphicEvent yellowButtonChanged
-		ifTrue: [ trEventClass := RSMouseRightDragStart ].
+		ifTrue: [ trEventClass := RSMouseRightDragStartEvent ].
 	aMorphicEvent blueButtonChanged
-		ifTrue: [ trEventClass := RSMouseMiddleDragStart ].
-	trEvent := self eventOfClass: trEventClass actionClass: RSMouseDragging from: aMorphicEvent.
+		ifTrue: [ trEventClass := RSMouseMiddleDragStartEvent ].
+	trEvent := self eventOfClass: trEventClass actionClass: RSMouseDraggingEvent from: aMorphicEvent.
 
 	shapeBeingPointed := trEvent shape.
 	shapeBeingPointed announce: trEvent.
@@ -205,7 +205,7 @@ RSAthensMorph >> eventMouseDragging: aMorphicEvent [
 	eventBeginingDragging ifNil: [ ^ self ].
 	step := aMorphicEvent position - eventBeginingDragging position.
 
-	trEvent := self eventOfClass: RSMouseDragging from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseDraggingEvent from: aMorphicEvent.
 	trEvent position: (roassalCanvas camera fromPixelToSpace: trEvent position).
 	trEvent step: step.
 
@@ -225,14 +225,14 @@ RSAthensMorph >> eventMouseDragging: aMorphicEvent [
 { #category : #'event-processed' }
 RSAthensMorph >> eventMouseEnter: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSMouseEnter from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseEnterEvent from: aMorphicEvent.
 	trEvent shape announce: trEvent.
 ]
 
 { #category : #'event-processed' }
 RSAthensMorph >> eventMouseLeave: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSMouseLeave from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseLeaveEvent from: aMorphicEvent.
 	shapeBeingPointed ifNotNil: [ 
 		trEvent shape: shapeBeingPointed].
 	trEvent shape announce: trEvent.
@@ -241,7 +241,7 @@ RSAthensMorph >> eventMouseLeave: aMorphicEvent [
 { #category : #'event-processed' }
 RSAthensMorph >> eventMouseMove: aMorphicEvent [
 	| trEvent |
-	trEvent := self eventOfClass: RSMouseMove from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseMoveEvent from: aMorphicEvent.
 	trEvent position: (roassalCanvas camera fromPixelToSpace: trEvent position).
 	trEvent shape announce: trEvent.
 ]
@@ -250,9 +250,9 @@ RSAthensMorph >> eventMouseMove: aMorphicEvent [
 RSAthensMorph >> eventMouseUp: aMorphicEvent [
 	| trEvent |
 	trEvent := self
-		mouseEventOfClass: RSMouseUp
-		ifLeftButton: RSMouseUpLeft  
-		ifRightButton: RSMouseUpRight
+		mouseEventOfClass: RSMouseUpEvent
+		ifLeftButton: RSMouseUpLeftEvent  
+		ifRightButton: RSMouseUpRightEvent
 		from: aMorphicEvent.
 	trEvent position: (roassalCanvas camera fromPixelToSpace: trEvent position).
 	trEvent shape announce: trEvent.
@@ -364,7 +364,7 @@ RSAthensMorph >> handleMouseOver: aMorphicEvent [
 	lastMousePosition := aMorphicEvent position.
 	currentElement == shapeBeingPointed 
 		ifTrue: [ ^ self ].
-	trEvent := self eventOfClass: RSMouseLeave from: aMorphicEvent.
+	trEvent := self eventOfClass: RSMouseLeaveEvent from: aMorphicEvent.
 	trEvent shape: shapeBeingPointed.
 	shapeBeingPointed announce: trEvent.
 	shapeBeingPointed := currentElement.

--- a/src/Roassal3/RSKeyDownEvent.class.st
+++ b/src/Roassal3/RSKeyDownEvent.class.st
@@ -16,7 +16,7 @@ c open
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 "
 Class {
-	#name : #RSKeyDown,
+	#name : #RSKeyDownEvent,
 	#superclass : #RSKeyboardEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSKeyUpEvent.class.st
+++ b/src/Roassal3/RSKeyUpEvent.class.st
@@ -16,7 +16,7 @@ c open
 ]]]
 "
 Class {
-	#name : #RSKeyUp,
+	#name : #RSKeyUpEvent,
 	#superclass : #RSKeyboardEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseClickEvent.class.st
+++ b/src/Roassal3/RSMouseClickEvent.class.st
@@ -2,7 +2,7 @@
 Common event for mouse clicks
 "
 Class {
-	#name : #RSMouseClick,
-	#superclass : #RSAbstractMouseClick,
+	#name : #RSMouseClickEvent,
+	#superclass : #RSAbstractMouseClickEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseDoubleClick.class.st
+++ b/src/Roassal3/RSMouseDoubleClick.class.st
@@ -1,8 +1,0 @@
-"
-Events for double clicks
-"
-Class {
-	#name : #RSMouseDoubleClick,
-	#superclass : #RSAbstractMouseClick,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseDoubleClickEvent.class.st
+++ b/src/Roassal3/RSMouseDoubleClickEvent.class.st
@@ -1,0 +1,8 @@
+"
+Events for double clicks
+"
+Class {
+	#name : #RSMouseDoubleClickEvent,
+	#superclass : #RSAbstractMouseClickEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseDoubleLeftClick.class.st
+++ b/src/Roassal3/RSMouseDoubleLeftClick.class.st
@@ -1,8 +1,0 @@
-"
-Double click for the left button
-"
-Class {
-	#name : #RSMouseDoubleLeftClick,
-	#superclass : #RSMouseDoubleClick,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseDoubleLeftClickEvent.class.st
+++ b/src/Roassal3/RSMouseDoubleLeftClickEvent.class.st
@@ -1,0 +1,8 @@
+"
+Double click for the left button
+"
+Class {
+	#name : #RSMouseDoubleLeftClickEvent,
+	#superclass : #RSMouseDoubleClickEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseDoubleRightClick.class.st
+++ b/src/Roassal3/RSMouseDoubleRightClick.class.st
@@ -1,8 +1,0 @@
-"
-Double clicks for right button
-"
-Class {
-	#name : #RSMouseDoubleRightClick,
-	#superclass : #RSMouseDoubleClick,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseDoubleRightClickEvent.class.st
+++ b/src/Roassal3/RSMouseDoubleRightClickEvent.class.st
@@ -1,0 +1,8 @@
+"
+Double clicks for right button
+"
+Class {
+	#name : #RSMouseDoubleRightClickEvent,
+	#superclass : #RSMouseDoubleClickEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseDragEndEvent.class.st
+++ b/src/Roassal3/RSMouseDragEndEvent.class.st
@@ -1,9 +1,9 @@
 "
-When: when a valid draggable element is grabbed
+When: at the end of DragDrop event
 Target: dragged element
 "
 Class {
-	#name : #RSMouseDragStart,
+	#name : #RSMouseDragEndEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseDragStartEvent.class.st
+++ b/src/Roassal3/RSMouseDragStartEvent.class.st
@@ -1,9 +1,9 @@
 "
-When: at the end of DragDrop event
+When: when a valid draggable element is grabbed
 Target: dragged element
 "
 Class {
-	#name : #RSMouseDragEnd,
+	#name : #RSMouseDragStartEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseDraggingEvent.class.st
+++ b/src/Roassal3/RSMouseDraggingEvent.class.st
@@ -3,7 +3,7 @@ When: during dragging of the element
 Target: dragged element
 "
 Class {
-	#name : #RSMouseDragging,
+	#name : #RSMouseDraggingEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#instVars : [
 		'step'
@@ -12,22 +12,22 @@ Class {
 }
 
 { #category : #'instance creation' }
-RSMouseDragging class >> step: aStepAsPoint [
+RSMouseDraggingEvent class >> step: aStepAsPoint [
 	^ self new step: aStepAsPoint
 ]
 
 { #category : #'initialize - release' }
-RSMouseDragging >> initialize [
+RSMouseDraggingEvent >> initialize [
 	super initialize.
 	step := 0 @ 0.
 ]
 
 { #category : #accessing }
-RSMouseDragging >> step [
+RSMouseDraggingEvent >> step [
 	^ step
 ]
 
 { #category : #accessing }
-RSMouseDragging >> step: aPoint [
+RSMouseDraggingEvent >> step: aPoint [
 	step := aPoint
 ]

--- a/src/Roassal3/RSMouseEnterEvent.class.st
+++ b/src/Roassal3/RSMouseEnterEvent.class.st
@@ -1,9 +1,9 @@
 "
-When: when a mouse cursor left an element
+When: when a mouse cursor entered an element
 Target: entered element
 "
 Class {
-	#name : #RSMouseLeave,
+	#name : #RSMouseEnterEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseLeaveEvent.class.st
+++ b/src/Roassal3/RSMouseLeaveEvent.class.st
@@ -1,9 +1,9 @@
 "
-When: when a mouse cursor entered an element
+When: when a mouse cursor left an element
 Target: entered element
 "
 Class {
-	#name : #RSMouseEnter,
+	#name : #RSMouseLeaveEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseLeftClickEvent.class.st
+++ b/src/Roassal3/RSMouseLeftClickEvent.class.st
@@ -2,7 +2,7 @@
 Common event for mouse left click
 "
 Class {
-	#name : #RSMouseLeftClick,
-	#superclass : #RSMouseClick,
+	#name : #RSMouseLeftClickEvent,
+	#superclass : #RSMouseClickEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseLeftDragStart.class.st
+++ b/src/Roassal3/RSMouseLeftDragStart.class.st
@@ -1,8 +1,0 @@
-"
-left buttom
-"
-Class {
-	#name : #RSMouseLeftDragStart,
-	#superclass : #RSMouseDragStart,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseLeftDragStartEvent.class.st
+++ b/src/Roassal3/RSMouseLeftDragStartEvent.class.st
@@ -1,0 +1,8 @@
+"
+left buttom
+"
+Class {
+	#name : #RSMouseLeftDragStartEvent,
+	#superclass : #RSMouseDragStartEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseMiddleDragStart.class.st
+++ b/src/Roassal3/RSMouseMiddleDragStart.class.st
@@ -1,8 +1,0 @@
-"
-middle button
-"
-Class {
-	#name : #RSMouseMiddleDragStart,
-	#superclass : #RSMouseDragStart,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseMiddleDragStartEvent.class.st
+++ b/src/Roassal3/RSMouseMiddleDragStartEvent.class.st
@@ -1,0 +1,8 @@
+"
+middle button
+"
+Class {
+	#name : #RSMouseMiddleDragStartEvent,
+	#superclass : #RSMouseDragStartEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseMoveEvent.class.st
+++ b/src/Roassal3/RSMouseMoveEvent.class.st
@@ -2,7 +2,7 @@
 Performed while mouse is moving over the morph
 "
 Class {
-	#name : #RSMouseMove,
+	#name : #RSMouseMoveEvent,
 	#superclass : #RSAbstractMouseEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseRightClickEvent.class.st
+++ b/src/Roassal3/RSMouseRightClickEvent.class.st
@@ -2,7 +2,7 @@
 Common event for mouse right clicks
 "
 Class {
-	#name : #RSMouseRightClick,
-	#superclass : #RSMouseClick,
+	#name : #RSMouseRightClickEvent,
+	#superclass : #RSMouseClickEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSMouseRightDragStart.class.st
+++ b/src/Roassal3/RSMouseRightDragStart.class.st
@@ -1,8 +1,0 @@
-"
-right button
-"
-Class {
-	#name : #RSMouseRightDragStart,
-	#superclass : #RSMouseDragStart,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseRightDragStartEvent.class.st
+++ b/src/Roassal3/RSMouseRightDragStartEvent.class.st
@@ -1,0 +1,8 @@
+"
+right button
+"
+Class {
+	#name : #RSMouseRightDragStartEvent,
+	#superclass : #RSMouseDragStartEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseUp.class.st
+++ b/src/Roassal3/RSMouseUp.class.st
@@ -1,8 +1,0 @@
-"
-Events for mouseUp
-"
-Class {
-	#name : #RSMouseUp,
-	#superclass : #RSAbstractMouseClick,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseUpEvent.class.st
+++ b/src/Roassal3/RSMouseUpEvent.class.st
@@ -1,0 +1,8 @@
+"
+Events for mouseUp
+"
+Class {
+	#name : #RSMouseUpEvent,
+	#superclass : #RSAbstractMouseClickEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseUpLeft.class.st
+++ b/src/Roassal3/RSMouseUpLeft.class.st
@@ -1,8 +1,0 @@
-"
-left buttom
-"
-Class {
-	#name : #RSMouseUpLeft,
-	#superclass : #RSMouseUp,
-	#category : #'Roassal3-Events'
-}

--- a/src/Roassal3/RSMouseUpLeftEvent.class.st
+++ b/src/Roassal3/RSMouseUpLeftEvent.class.st
@@ -1,0 +1,8 @@
+"
+left buttom
+"
+Class {
+	#name : #RSMouseUpLeftEvent,
+	#superclass : #RSMouseUpEvent,
+	#category : #'Roassal3-Events'
+}

--- a/src/Roassal3/RSMouseUpRightEvent.class.st
+++ b/src/Roassal3/RSMouseUpRightEvent.class.st
@@ -2,7 +2,7 @@
 Event for mouse up right
 "
 Class {
-	#name : #RSMouseUpRight,
-	#superclass : #RSMouseUp,
+	#name : #RSMouseUpRightEvent,
+	#superclass : #RSMouseUpEvent,
 	#category : #'Roassal3-Events'
 }

--- a/src/Roassal3/RSObjectWithProperty.class.st
+++ b/src/Roassal3/RSObjectWithProperty.class.st
@@ -73,7 +73,7 @@ box click.
 c
 -=-=-=-=-=-=-=-=-=
 "
-	self announcer announce: (RSMouseClick new 
+	self announcer announce: (RSMouseClickEvent new 
 		canvas: self canvas;
 		shape: self; 
 		yourself).


### PR DESCRIPTION
Adding the Event suffix to classes:
RSAbstractMouseClick
RSMouseClick
RSMouseLeftClick
RSMouseRightClick
RSMouseDoubleClick
RSMouseDoubleLeftClick
RSMouseDoubleRightClick
RSMouseUp
RSMouseUpLeft
RSMouseUpRight
RSMouseDragEnd
RSMouseDragStart
RSMouseLeftDragStart
RSMouseMiddleDragStart
RSMouseRightDragStart
RSMouseDragging
RSMouseEnter
RSMouseLeave
RSMouseMove
RSKeyDown
RSKeyUp