### PR TITLE
Make RSAbstractUMLClassRenderer actually use #insVarSelector.

### DIFF
--- a/src/Roassal3-UML/RSAbstractUMLClassRenderer.class.st
+++ b/src/Roassal3-UML/RSAbstractUMLClassRenderer.class.st
@@ -239,11 +239,12 @@ RSAbstractUMLClassRenderer >> titleFor: model [
 
 { #category : #hooks }
 RSAbstractUMLClassRenderer >> varFor: model [
+
 	^ RSLabel new
-		model: model;
-		color: self textColor;
-		text: model;
-		yourself
+		  model: model;
+		  color: self textColor;
+		  text: (modelDescriptor instVarSelector rsValue: model);
+		  yourself
 ]
 
 { #category : #hooks }


### PR DESCRIPTION
This was done using `RSAbstractUMLClassRenderer>>#methodFor:` asTemplate.