### PR TITLE
Iss loadfull without confirms

### DIFF
--- a/src/Roassal3-Menu/RSWorldMenu.class.st
+++ b/src/Roassal3-Menu/RSWorldMenu.class.st
@@ -46,9 +46,10 @@ RSWorldMenu class >> loadFullVersion [
 	EpMonitor disableDuring: [ 
 		Metacello new
 			baseline: 'Roassal3';
-			onConflictUseIncoming;
+			onWarningLog;
 			repository: 'github://ObjectProfile/Roassal3';
 			load ].
+	self inform: 'Finished loading full version of Roassal 3'
 ]
 
 { #category : #menu }

--- a/src/Roassal3-Menu/RSWorldMenu.class.st
+++ b/src/Roassal3-Menu/RSWorldMenu.class.st
@@ -41,10 +41,14 @@ RSWorldMenu class >> loadFullStableVersion [
 
 { #category : #menu }
 RSWorldMenu class >> loadFullVersion [
-	Metacello new
-    baseline: 'Roassal3';
-    repository: 'github://ObjectProfile/Roassal3';
-    load.
+	" Load the full version of Roassal 3 unattended mode (without confirm dialogs) "
+
+	EpMonitor disableDuring: [ 
+		Metacello new
+			baseline: 'Roassal3';
+			onConflictUseIncoming;
+			repository: 'github://ObjectProfile/Roassal3';
+			load ].
 ]
 
 { #category : #menu }


### PR DESCRIPTION
Enable loading the full version of Roassal 3 unattended mode (without confirm dialogs) from the World menu item.