### PR TITLE
Fix issue in RSSankey boxes position

### DIFF
--- a/src/Roassal3-Experimental/RSSankey.class.st
+++ b/src/Roassal3-Experimental/RSSankey.class.st
@@ -50,46 +50,49 @@ RSSankey >> centerOf: box [
 
 { #category : #private }
 RSSankey >> computeBoxesBreadths [
+
 	| remainingBoxes nextBoxes x kx |
 	x := 0.
 	remainingBoxes := boxes.
-	[ remainingBoxes size isZero ] whileFalse: [ 
+	[ remainingBoxes notEmpty and: [ x < boxes size ] ] whileTrue: [ 
 		nextBoxes := OrderedCollection new.
-		remainingBoxes do: [ :box |
+		remainingBoxes do: [ :box | 
 			box propertyAt: #x put: x.
-			nextBoxes addAll: ((box propertyAt: #sourceLinks) collect: #to) ].
+			nextBoxes addAll: ((box propertyAt: #sourceLinks)
+					 collect: #to
+					 thenReject: [ :each | nextBoxes includes: each ]) ].
 		remainingBoxes := nextBoxes.
-		x := x + 1.
-	 ].
-	
+		x := x + 1 ].
+
 	kx := extent x / (x - 1).
-	boxes do: [ :box | | x1 |
+	boxes do: [ :box | 
+		| x1 |
 		(box propertyAt: #sourceLinks) ifEmpty: [ 
-			box propertyAt: #x put: x - 1.
-			 ].
+			box propertyAt: #x put: x - 1 ].
 		x1 := box propertyAt: #x.
-		box propertyAt: #x put: x1 * kx
-		 ]
+		box propertyAt: #x put: x1 * kx ]
 ]
 
 { #category : #private }
 RSSankey >> computeBoxesDepths [
+
 	| boxesByBreadth alpha |
 	boxesByBreadth := boxes groupedBy: [ :e | e propertyAt: #x ].
-	boxesByBreadth := boxesByBreadth keysSortedSafely 
-		collect: [:k | boxesByBreadth at: k ].
+	boxesByBreadth := boxesByBreadth keysSortedSafely collect: [ :k | 
+		                  boxesByBreadth at: k ].
 	boxesByBreadth ifEmpty: [ ^ self ].
-	boxesByBreadth last do: [ :e |
-		e propertyAt: #last put: true ].
+	boxesByBreadth last do: [ :e | e propertyAt: #last put: true ].
 	self setupBoxesDepth: boxesByBreadth.
 	self resolveCollisions: boxesByBreadth.
+	self computeLinesDepths.
 	alpha := 1.
-	1 to: iterations do: [ :i |
-		self relaxRightToLeft: (alpha := alpha *0.99) boxes: boxesByBreadth.
+	1 to: iterations do: [ :i | 
+		self relaxRightToLeft: (alpha := alpha * 0.99) boxes: boxesByBreadth.
 		self resolveCollisions: boxesByBreadth.
+		self computeLinesDepths.
 		self relaxLeftToRight: alpha boxes: boxesByBreadth.
-		self resolveCollisions: boxesByBreadth.]
-	
+		self resolveCollisions: boxesByBreadth.
+		self computeLinesDepths ]
 ]
 
 { #category : #private }
@@ -103,22 +106,21 @@ RSSankey >> computeBoxesValues [
 
 { #category : #private }
 RSSankey >> computeLinesDepths [
-	boxes do: [ :box |
-		(box propertyAt: #sourceLinks) sort: [:a :b | 
-			(a to propertyAt: #y) < (b from propertyAt: #y) ].
-		(box propertyAt: #targetLinks) sort:  [ :a :b | 
-			(a from propertyAt: #y) < (b to propertyAt: #y) ].
-		 ].
-	boxes do: [ :box | | sy ty|
+
+	boxes do: [ :box | 
+		(box propertyAt: #sourceLinks) sort: [ :a :b | 
+			(a to propertyAt: #y) < (b to propertyAt: #y) ].
+		(box propertyAt: #targetLinks) sort: [ :a :b | 
+			(a from propertyAt: #y) < (b from propertyAt: #y) ] ].
+	boxes do: [ :box | 
+		| sy ty |
 		sy := ty := 0.
-		(box propertyAt: #sourceLinks) do: [ :line |
+		(box propertyAt: #sourceLinks) do: [ :line | 
 			line propertyAt: #sy put: sy.
 			sy := sy + (line propertyAt: #dy) ].
-		(box propertyAt: #targetLinks) do: [ :line |
+		(box propertyAt: #targetLinks) do: [ :line | 
 			line propertyAt: #ty put: ty.
-			ty := ty + (line propertyAt: #dy) ].
-		 ].
-	
+			ty := ty + (line propertyAt: #dy) ] ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
Hello there

I'm using RSSankey for a personal project, I noticed an issue in the way lines are drawn: lines cross each other when they shouldn't (see below)

![original](https://user-images.githubusercontent.com/49032546/142728718-66ff32ea-7184-4f2e-aea0-9ab35ff73f79.png)

Code I used to generate the graph:

```
| b links |
links := { 
         (RSSankeyLink new
	          from: #Source;
	          to: #Destination1;
	          value: 1;
	          yourself).
         (RSSankeyLink new
	          from: #Source;
	          to: #Destination2;
	          value: 1;
	          yourself).
         (RSSankeyLink new
	          from: #Source;
	          to: #Destination3;
	          value: 1;
	          yourself) }.
b := RSSankey new.
b boxShape
	withBorder;
	borderColor: Color black;
	width: 15.
b
	extent: 960 @ 500;
	iterations: 32;
	nodePadding: 10;
	nodes: #( #Source #Destination1 #Destination2 #Destination3 );
	links: links.
b open
```

I modified a little bit RSSankey to compute boxes positions correctly, now the graph looks like this:

![new](https://user-images.githubusercontent.com/49032546/142728723-1050ad4c-daa2-4b05-a8e3-3e629efbc352.png)

