### PR TITLE
Fix #434

### DIFF
--- a/src/Roassal3-Shapes/RSBoundingShape.class.st
+++ b/src/Roassal3-Shapes/RSBoundingShape.class.st
@@ -205,10 +205,13 @@ RSBoundingShape >> height: aNumber [
 
 { #category : #testing }
 RSBoundingShape >> includesPoint: aPoint [
-	"Return true if the provided point is included in the encompassing rectangle of the shape."
-	| invertedPoint |
-	invertedPoint := matrix rsInverseTransform: aPoint.
-	^ self baseRectangle containsPoint: invertedPoint.
+	"Return true if the provided point is included in the shape"	
+
+	"First we check if the encompassingRectangle has the point. If the point is outside, there is not need to transform the point"
+	(self encompassingRectangle containsPoint: aPoint)
+		ifFalse: [ ^ false ].
+	
+	^ self preciseIncludesPoint: aPoint
 ]
 
 { #category : #'edges - deprecated' }
@@ -342,6 +345,17 @@ RSBoundingShape >> positionInCanvas [
 RSBoundingShape >> postCopy [
 	super postCopy.
 	self matrix: self matrix copy
+]
+
+{ #category : #testing }
+RSBoundingShape >> preciseIncludesPoint: aPoint [
+	
+	"Return true if the provided point is precisily included in the shape. Taking care of the transformation (aka scaling, position, rotation)"
+	
+	| invertedPoint |
+		
+	invertedPoint := matrix rsInverseTransform: aPoint.
+	^ self baseRectangle containsPoint: invertedPoint.
 ]
 
 { #category : #actions }

--- a/src/Roassal3-Shapes/RSCircle.class.st
+++ b/src/Roassal3-Shapes/RSCircle.class.st
@@ -49,7 +49,7 @@ RSCircle >> height: anInteger [
 ]
 
 { #category : #testing }
-RSCircle >> includesPoint: aPoint [
+RSCircle >> preciseIncludesPoint: aPoint [
 	"Implementation is taken over from EllipseMorph>>containsPoint:"
 	| invertedPoint radius other delta xOverY t1 t2 rect |
 	invertedPoint := matrix rsInverseTransform: aPoint.

--- a/src/Roassal3-Shapes/RSEllipse.class.st
+++ b/src/Roassal3-Shapes/RSEllipse.class.st
@@ -38,7 +38,7 @@ RSEllipse >> geometry [
 ]
 
 { #category : #testing }
-RSEllipse >> includesPoint: aPoint [
+RSEllipse >> preciseIncludesPoint: aPoint [
 	"Implementation is taken over from EllipseMorph>>containsPoint:"
 	| invertedPoint radius other delta xOverY t1 t2 rect |
 	invertedPoint := matrix rsInverseTransform: aPoint.

--- a/src/Roassal3-Shapes/RSPieSlice.class.st
+++ b/src/Roassal3-Shapes/RSPieSlice.class.st
@@ -108,28 +108,6 @@ RSPieSlice >> externalRadius: eR [
 	self extent: (eR * 2) asPoint.
 ]
 
-{ #category : #testing }
-RSPieSlice >> includesPoint: aPoint [
-	| invertedPoint a b i e n d |
-	invertedPoint := matrix rsInverseTransform: aPoint.
-	(self baseRectangle containsPoint: invertedPoint)
-		ifFalse: [ ^ false ].
-	i := innerRadius.
-	e := externalRadius.
-	d := invertedPoint distanceTo: 0 @ 0.
-	(d between: i and: e)
-		ifFalse: [ ^ false ].
-	n := invertedPoint angle negated radiansToDegrees.
-	a := alphaAngle.
-	b := betaAngle.
-	n := (360 + (n % 360)) % 360.
-	a := (3600000 + a) % 360.
-	b := (3600000 + b) % 360.
-	^ a < b
-		ifTrue: [ n between: a and: b ]
-		ifFalse: [ a <= n | (n <= b) ]
-]
-
 { #category : #initialization }
 RSPieSlice >> initialize [
 	super initialize.
@@ -154,6 +132,28 @@ RSPieSlice >> innerRadius: iR [
 { #category : #accessing }
 RSPieSlice >> middleAngle [
 	^ (alphaAngle + betaAngle) / 2
+]
+
+{ #category : #testing }
+RSPieSlice >> preciseIncludesPoint: aPoint [
+	| invertedPoint a b i e n d |
+	invertedPoint := matrix rsInverseTransform: aPoint.
+	(self baseRectangle containsPoint: invertedPoint)
+		ifFalse: [ ^ false ].
+	i := innerRadius.
+	e := externalRadius.
+	d := invertedPoint distanceTo: 0 @ 0.
+	(d between: i and: e)
+		ifFalse: [ ^ false ].
+	n := invertedPoint angle negated radiansToDegrees.
+	a := alphaAngle.
+	b := betaAngle.
+	n := (360 + (n % 360)) % 360.
+	a := (3600000 + a) % 360.
+	b := (3600000 + b) % 360.
+	^ a < b
+		ifTrue: [ n between: a and: b ]
+		ifFalse: [ a <= n | (n <= b) ]
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Shapes/RSPolygon.class.st
+++ b/src/Roassal3-Shapes/RSPolygon.class.st
@@ -185,17 +185,6 @@ RSPolygon >> hasPoints [
 	^ points notNil and: [ points isNotEmpty ]
 ]
 
-{ #category : #testing }
-RSPolygon >> includesPoint: aPoint [
-	"Return true or false if a point is contained in the shape"
-	| invertedPoint |
-	invertedPoint := matrix rsInverseTransform: aPoint.
-	^ (self baseRectangle containsPoint: invertedPoint)
-		ifFalse: [ false ]
-		ifTrue: [(AthensPolygonTester new 
-			polygon: points) includesPoint: invertedPoint]
-]
-
 { #category : #initialization }
 RSPolygon >> initialize [
 	super initialize.
@@ -216,6 +205,17 @@ RSPolygon >> points: anArray [
 	rec := self centerPoints.
 	self translateTo: rec floatCenter.
 	super extent: rec extent
+]
+
+{ #category : #testing }
+RSPolygon >> preciseIncludesPoint: aPoint [
+	"Return true or false if a point is contained in the shape"
+	| invertedPoint |
+	invertedPoint := matrix rsInverseTransform: aPoint.
+	^ (self baseRectangle containsPoint: invertedPoint)
+		ifFalse: [ false ]
+		ifTrue: [(AthensPolygonTester new 
+			polygon: points) includesPoint: invertedPoint]
 ]
 
 { #category : #private }


### PR DESCRIPTION
Improving the speed of the testing if a shape has a point.
First we check if it is included in the encompassingRectangle and then if it is inside, we check more precise point.