### PR TITLE
Updated Fuel to 5.0.2 (Pharo 11)

### DIFF
--- a/src/Roassal3-Global-Tests/RSMonitorEventsTest.class.st
+++ b/src/Roassal3-Global-Tests/RSMonitorEventsTest.class.st
@@ -48,7 +48,13 @@ RSMonitorEventsTest >> testWriteToFile [
 	
 	fileName := Time microsecondClockValue asString, '.fuel'.
 	
-	storage := FLSerializer serializeToByteArray: events.
-	self assert: storage size > 100.
+	storage := ByteArray
+		new: 100
+		streamContents: [ :stream |
+			FLSerializer new
+				onStream: stream;
+				object: events;
+				serialize ].
+	self assert: storage size > 100
 	
 ]


### PR DESCRIPTION
Note: this change is _not_ compatible with older versions of Fuel. This is specific to updating Fuel to v5 in Pharo 11.