### PR TITLE
Added ticks by default to charts

### DIFF
--- a/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
@@ -24,12 +24,10 @@ RSBarChartExample >> example01TwoBars [
 	p2 barOffset: size / -2.
 	c addPlot: p.
 	c addPlot: p2.
-	c addDecoration: (RSHorizontalTick new
-			 doNotUseNiceLabel;
+	c horizontalTick doNotUseNiceLabel;
 			 numberOfTicks: x size - 1;
 			 asFloat: 5;
-			 useVerticalLabel;
-			 yourself).
+			 useVerticalLabel.
 
 	c build.
 	p bars @ RSPopup.
@@ -133,8 +131,8 @@ RSBarChartExample >> example03TilePaint [
 		lb text: (labels at: index) withBoxColor: color.
 		].
 
-	c addDecoration: (RSHorizontalTick new fromNames: #(Math Science); labelRotation: 0 ).
-	c addDecoration: (RSVerticalTick new numberOfTicks: 5).
+	c horizontalTick fromNames: #(Math Science); labelRotation: 0.
+	c verticalTick numberOfTicks: 5.
 	c ylabel: 'Number of students'.
 	c xlabel: 'Class'.
 	c build.
@@ -156,8 +154,8 @@ RSBarChartExample >> example04VerticalStack [
 	c barHeights: menMeans.
 	(c barHeights: womenMeans)
 		bottom: menMeans.
-	c addDecoration: (RSHorizontalTick new fromNames: #(Day1 Day2 Day3 Day4 Day5)).
-	c addDecoration: (RSVerticalTick new integer).
+	c horizontalTick fromNames: #(Day1 Day2 Day3 Day4 Day5).
+	c verticalTick integer.
 	c ylabel: 'Scores'.
 	c title: 'Scores by group of gender'.
 	c build.
@@ -181,8 +179,8 @@ RSBarChartExample >> example05HorizontalStack [
 	c barWidths: menMeans.
 	(c barWidths: womenMeans)
 		left: menMeans.
-	c addDecoration: (RSHorizontalTick new integer).
-	c addDecoration: (RSVerticalTick new fromNames: #(Day1 Day2 Day3 Day4 Day5)).
+	c horizontalTick integer.
+	c verticalTick fromNames: #(Day1 Day2 Day3 Day4 Day5).
 	c xlabel: 'Scores'.
 	c title: 'Scores by group of gender'.
 	c build.
@@ -245,7 +243,7 @@ RSBarChartExample >> example07DoubleBar [
 			         x1: x1 x2: x2 y: y;
 			         yourself).
 
-	c addDecoration: (RSHorizontalTick new numberOfTicks: 10).
+	c horizontalTick numberOfTicks: 10.
 	c addDecoration: (RSHorizontalTopTick new
 			 values: x2;
 			 numberOfTicks: 10).
@@ -253,8 +251,7 @@ RSBarChartExample >> example07DoubleBar [
 	c xlabel: 'Number Of Methods'.
 	c xlabelTop: 'Number Of Variables'.
 
-	c addDecoration:
-		(RSVerticalTick new fromNames: (classes collect: #name)).
+	c verticalTick fromNames: (classes collect: #name).
 	c addDecoration: (RSVerticalRightTick new
 			 values: (1 to: classes size);
 			 numberOfTicks: 10;

--- a/src/Roassal3-Chart-Examples/RSBoxPlotExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBoxPlotExample.class.st
@@ -21,12 +21,10 @@ RSBoxPlotExample >> example01 [
 
 	c addPlot: p.
 
-	c addDecoration: (RSHorizontalTick new
-		numberOfTicks: y size).
+	c horizontalTick numberOfTicks: y size.
 	c xlabel: 'X Axis'.
-	c addDecoration: (RSVerticalTick new
-		numberOfTicks: 10;
-		asFloat).
+	c verticalTick numberOfTicks: 10;
+		asFloat.
 	c ylabel: 'Y Axis'.
 	c title: 'Box Plot'.
 	^ c
@@ -70,8 +68,8 @@ RSBoxPlotExample >> example02 [
 	c addPlot: p.
 	c addPlot: p2.
 	c addPlot: p3.
-	c addDecoration: (RSHorizontalTick new fromNames: x).
-	c addDecoration: (RSVerticalTick new integer).
+	c horizontalTick fromNames: x.
+	c verticalTick integer.
 
 	^ c
 ]

--- a/src/Roassal3-Chart-Examples/RSChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSChartExample.class.st
@@ -16,8 +16,7 @@ RSChartExample >> example01Markers [
 	p := RSLinePlot new.
 	p x: x y: x sin * 0.22 + 0.5.
 	c addPlot: p.
-	c addDecoration: RSHorizontalTick new.
-	c addDecoration: RSVerticalTick new asFloat.
+	c verticalTick asFloat.
 	c addDecoration: RSYMarkerDecoration new average.
 	c addDecoration: RSYMarkerDecoration new min.
 	c addDecoration: RSYMarkerDecoration new max.
@@ -68,14 +67,15 @@ RSChartExample >> example03Plot [
 { #category : #examples }
 RSChartExample >> example04WithTick [
 	<script: 'self new example04WithTick show'>
-	| x |
+	| x chart |
 	x := -10.0 to: 20.0 count: 100.
-	^ RSChart new
+	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
-		addDecoration: RSHorizontalTick new integer;
-		addDecoration: RSVerticalTick new integer;
-		yourself
+		yourself.
+	chart horizontalTick integer.
+	chart verticalTick integer.
+	^ chart
 ]
 
 { #category : #examples }
@@ -87,26 +87,26 @@ RSChartExample >> example05WithTick [
 	1 to: 7 do: [ :i |
 		c addPlot: (RSLinePlot new x: x y: (i * 0.3 + x) sin * (7 - i))
 	].
-	c addDecoration: RSVerticalTick new integer.
-	c addDecoration: RSHorizontalTick new integer.
+	c verticalTick integer.
+	c horizontalTick integer.
 	^ c
 ]
 
 { #category : #examples }
 RSChartExample >> example06CustomNumberOfTicks [
 	<script: 'self new example06CustomNumberOfTicks show'>
-	| x |
+	| x chart |
 	x := -10.0 to: 20.0 count: 100.
-	^ RSChart new
+	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
-		addDecoration: (RSHorizontalTick new
-			numberOfTicks: 20;
-			integer);
-		addDecoration: (RSVerticalTick new integer
+		yourself.
+	chart horizontalTick numberOfTicks: 20;
+			integer.
+	chart verticalTick integer
 			numberOfTicks: 2;
-			doNotUseNiceLabel);
-		yourself
+			doNotUseNiceLabel.
+	^ chart
 ]
 
 { #category : #examples }
@@ -167,7 +167,8 @@ RSChartExample >> example09LinearSqrtSymlog [
 		| chart |
 		chart := RSChart new.
 		chart addPlot: (RSLinePlot new x: x y: y).
-		chart addDecoration: (RSVerticalTick new asFloat).
+		chart verticalTick asFloat.
+		chart removeHorizontalTicks.
 		chart perform: sel.
 		chart title: sel.
 		chart asShape ]).
@@ -187,14 +188,12 @@ RSChartExample >> example10BarPlot [
 
 	c addPlot: p.
 
-	c addDecoration: (RSHorizontalTick new
-		doNotUseNiceLabel;
+	c horizontalTick doNotUseNiceLabel;
 		numberOfTicks: x size - 1;
-		asFloat).
+		asFloat.
 	c xlabel: 'X Axis'.
-	c addDecoration: (RSVerticalTick new
-		numberOfTicks: 10;
-		asFloat).
+	c verticalTick numberOfTicks: 10;
+		asFloat.
 	c ylabel: 'Y Axis'.
 	c title: 'Histogram'.
 	^ c
@@ -210,10 +209,9 @@ RSChartExample >> example11BarplotCombinedWithLine [
 
 	c addPlot: (RSBarPlot new x: x y: y).
 	c addPlot: (RSLinePlot new x: x y: y; color: Color red).
-	c addDecoration: (RSHorizontalTick new asFloat).
-	c addDecoration: (RSVerticalTick new
-		numberOfTicks: 10;
-		asFloat).
+	c horizontalTick asFloat.
+	c verticalTick numberOfTicks: 10;
+		asFloat.
 	c xlabel: 'X Axis'.
 	c ylabel: 'Y Axis'.
 	c title: 'Bar char'.
@@ -240,8 +238,7 @@ RSChartExample >> example12ScatterPlotAndNormalizer [
 
 	c addPlot: p.
 
-	c addDecoration: (RSHorizontalTick new doNotUseNiceLabel asFloat: 3).
-	c addDecoration: RSVerticalTick new.
+	c horizontalTick doNotUseNiceLabel asFloat: 3.
 	c build.
 	p ellipses models: z.
 		RSNormalizer size
@@ -273,8 +270,7 @@ RSChartExample >> example19PositiveNetagiveBarPlots [
 	d2 y: #(-5 -6 -3 -3).
 	c addPlot: d2.
 
-	c addDecoration: (RSVerticalTick new integer).
-	c addDecoration: (RSHorizontalTick new).
+	c verticalTick integer.
 
 	c addDecoration: (RSYLabelDecoration new title: 'Difference'; rotationAngle: -90; offset: -25 @ 0).
 	c addDecoration: (RSXLabelDecoration new title: 'Evolution').
@@ -291,10 +287,10 @@ RSChartExample >> example20Grid [
 	x := 0 to: 10.
 	y := x raisedTo: 2.
 	c lineX: x y: y.
-	c addDecoration: (vertical := RSVerticalTick new).
+	vertical := c verticalTick.
 	vertical shape dashed.
 	vertical configuration tickSize: c extent x negated.
-	c addDecoration: (horizontal := RSHorizontalTick new).
+	horizontal := c horizontalTick.
 	horizontal configuration tickSize: c extent y negated.
 	c build.
 	^ c canvas
@@ -397,8 +393,7 @@ RSChartExample >> example22CustomPopup [
 			yourself)).
 	(c lineX: x y: y) color: Color gray.
 
-	c addDecoration: (RSVerticalTick new).
-	c addDecoration: (RSHorizontalTick new fromNames: names; useDiagonalLabel).
+	c horizontalTick fromNames: names; useDiagonalLabel.
 	c addDecoration: popup.
 	popup chartPopupBuilder: (RSBlockChartPopupBuilder new
 		rowShapeBlock: [:plot :point |
@@ -440,8 +435,6 @@ RSChartExample >> example24SpineLine [
 	c lineX: x y: y.
 	c spineDecoration: (spine := RSLineSpineDecoration new).
 	spine shape format: '^'.
-	c add: RSHorizontalTick new.
-	c add: RSVerticalTick new.
 	c padding: 10.
 	^ c
 ]

--- a/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
@@ -15,8 +15,7 @@ RSHistogramExample >> example01RandomValues [
 	c := RSChart new.
 	p := RSLinePlot new x:(1 to: values size) y: values.
 	c addPlot: p.
-	c addDecoration: (RSHorizontalTick new doNotUseNiceLabel).
-	c addDecoration: (RSVerticalTick new).
+	c horizontalTick doNotUseNiceLabel.
 	^ c
 ]
 
@@ -28,8 +27,6 @@ RSHistogramExample >> example02Histogram [
 	c := RSChart new.
 	plot := RSHistogramPlot new x: values.
 	c addPlot: plot.
-	c addDecoration: RSVerticalTick new.
-	c addDecoration: RSHorizontalTick new.
 	c title: 'My Chart'.
 	^ c
 ]
@@ -46,8 +43,6 @@ RSHistogramExample >> example03Bins [
 		c container: g.
 		plot := RSHistogramPlot new x: values; numberOfBins: numberOfBins.
 		c addPlot: plot.
-		c addDecoration: RSVerticalTick new.
-		c addDecoration: RSHorizontalTick new.
 		c title: numberOfBins.
 		c build.
 		g asShapeFor: numberOfBins.
@@ -75,8 +70,6 @@ RSHistogramExample >> example04BinningStrat [
 		c container: g.
 		plot := RSHistogramPlot new x: values; binningStrategy: strat.
 		c addPlot: plot.
-		c addDecoration: RSVerticalTick new.
-		c addDecoration: RSHorizontalTick new.
 		c title: strat class name.
 		c build.
 		g asShapeFor: strat.
@@ -154,8 +147,7 @@ RSHistogramExample >> example08Strategies [
 		y := x collect: [ :v | strat computeNumberOfBinsFor: (Array new: v) ].
 		plot := RSLinePlot new x: x y: y.
 		c addPlot: plot.
-		c addDecoration: RSVerticalTick new doNotUseNiceLabel.
-		c addDecoration: RSHorizontalTick new.
+		c verticalTick doNotUseNiceLabel.
 		c title: strat class name.
 		c build.
 		g asShapeFor: strat.
@@ -175,8 +167,6 @@ RSHistogramExample >> example09BinsCollection [
 	plot := RSHistogramPlot new x: values.
 	plot bins: #(100 150 155 180 200).
 	c addPlot: plot.
-	c addDecoration: RSVerticalTick new.
-	c addDecoration: RSHorizontalTick new.
 	^ c
 ]
 
@@ -194,11 +184,10 @@ RSHistogramExample >> example10Objects [
 	plot := RSHistogramPlot new x: values.
 	plot bins: (0 to: 1000 by: 20) , {1000. 2000. 3000 }.
 
-	c add: (tick := RSVerticalTick new).
+	tick := c verticalTick.
 	tick configuration tickSize: -300.
 	tick color: Color lightGray.
 	tick shape width: 0.5.
-	c add: RSHorizontalTick new.
 	c add: plot.
 	c build.
 

--- a/src/Roassal3-Chart-Examples/RSTimelineExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSTimelineExample.class.st
@@ -45,13 +45,11 @@ RSTimelineExample >> example01Gantt [
 		plot entries: line at: index.
 		chart addPlot: plot.
 	].
-	chart addDecoration: (RSVerticalTick new fromNames: names).
-	chart addDecoration: (RSHorizontalTick new
-		doNotUseNiceLabel;
+	chart verticalTick fromNames: names.
+	chart horizontalTick doNotUseNiceLabel;
 		numberOfTicks: 5;
 		useDiagonalLabel;
-		labelConversion: [ :v | Date year: 2021 day: v ];
-		yourself).
+		labelConversion: [ :v | Date year: 2021 day: v ].
 	chart build.
 	chart plots doWithIndex: [ :p :index |
 		p bars @ (RSPopup text: [ :assoc |
@@ -77,13 +75,11 @@ RSTimelineExample >> example02Labeled [
 		plot entries: line at: index.
 		chart addPlot: plot.
 	].
-	chart addDecoration: (RSVerticalTick new fromNames: names).
-	chart addDecoration: (RSHorizontalTick new
-		doNotUseNiceLabel;
+	chart verticalTick fromNames: names.
+	chart horizontalTick doNotUseNiceLabel;
 		numberOfTicks: 5;
 		useDiagonalLabel;
-		labelConversion: [ :v | Date year: 2021 day: v ];
-		yourself).
+		labelConversion: [ :v | Date year: 2021 day: v ].
 	chart build.
 	chart plots doWithIndex: [ :p :index |
 		p bars
@@ -111,13 +107,11 @@ RSTimelineExample >> example03ZoomInAxis [
 		 RSTimeLinePlot new
 			entries: line at: index;
 			yourself ]).
-	chart add: (RSVerticalTick new fromNames: names).
-	chart add: (RSHorizontalTick new
-		doNotUseNiceLabel;
+	chart verticalTick fromNames: names.
+	chart horizontalTick doNotUseNiceLabel;
 		numberOfTicks: 10;
 		useDiagonalLabel;
-		labelConversion: [ :day | self printDate: day ];
-		yourself).
+		labelConversion: [ :day | self printDate: day ].
 	chart add: RSZoomTickDecoration new.
 	^ chart
 ]

--- a/src/Roassal3-Chart-Tests/RSAbstractChartTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSAbstractChartTest.class.st
@@ -35,14 +35,12 @@ RSAbstractChartTest >> testEmptyPlot [
 	| p |
 	p := self classToTest new x: #( 0 ) y: #( 0 ).
 	chart addPlot: p.
-	chart addDecoration: (RSVerticalTick new integer
+	chart verticalTick integer;
 			 numberOfTicks: 1;
-			 fontSize: 10;
-			 yourself).
-	chart addDecoration: (RSHorizontalTick new integer
+			 fontSize: 10.
+	chart horizontalTick integer;
 			 numberOfTicks: 1;
-			 fontSize: 10;
-			 yourself).
+			 fontSize: 10.
 	chart build
 ]
 

--- a/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
@@ -17,8 +17,8 @@ RSBarPlotTest >> test2BarPlots [
 	extent := chart extent.
 	chart addPlot: (RSBarPlot new y: d1).
 	chart addPlot: (RSBarPlot new y: d2).
-	vtick := RSVerticalTick new withNoLabels.
-	chart addDecoration: vtick.
+	vtick := chart verticalTick withNoLabels.
+	chart removeHorizontalTicks.
 	chart build.
 	self
 		assert: chart canvas encompassingRectangle extent
@@ -52,9 +52,8 @@ RSBarPlotTest >> testVerticalBar [
 	self assert: p isVerticalBarPlot.
 	self deny: p isHorizontalBarPlot.
 	c addPlot: p.
-	c addDecoration: (RSVerticalTick new
-		numberOfTicks: 10;
-		asFloat).
+	c verticalTick numberOfTicks: 10;
+		asFloat.
 	c build.
 	self assert: (p bars allSatisfy: [ :shape |
 		 shape width closeTo: p bars anyOne width ])

--- a/src/Roassal3-Chart-Tests/RSChartTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTest.class.st
@@ -11,8 +11,6 @@ RSChartTest >> testBasic [
 	RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
-		addDecoration: RSHorizontalTick new;
-		addDecoration: RSVerticalTick new;
 		build
 ]
 
@@ -98,6 +96,7 @@ RSChartTest >> testMustInclude03 [
 	y := #(-10 -13 -15).
 	x := #(4 6 9).
 	c := RSChart new.
+	c removeAllTicks.
 	c addPlot: (RSLinePlot new x: x y: y).
 	c mustInclude0inX.
 	c build.
@@ -116,6 +115,7 @@ RSChartTest >> testMustInclude04 [
 		y add: x sin ].
 
 	c := RSChart new.
+	c removeAllTicks.
 	c addPlot: (RSLinePlot new y: y).
 	c build.
 
@@ -132,6 +132,7 @@ RSChartTest >> testMustInclude05 [
 		y add: x sin ].
 
 	c := RSChart new.
+	c removeAllTicks.
 	c addPlot: (RSLinePlot new y: y).
 	c mustInclude0inY.
 	c build.
@@ -154,8 +155,6 @@ RSChartTest >> testSameMinMax [
 		fontSize: 20).
 	chart xlabel: 'Episode' offset: 0 @ 10.
 	chart ylabel: 'Reward' offset: -20 @ 0.
-	chart addDecoration: RSHorizontalTick new.
-	chart addDecoration: RSVerticalTick new.
 	chart build
 ]
 
@@ -163,11 +162,10 @@ RSChartTest >> testSameMinMax [
 RSChartTest >> testStylerDefault [
 	| x tick chart |
 	x := -10.0 to: 20.0 count: 100.
-	tick := RSHorizontalTick new.
 	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
-		addDecoration: tick;
 		yourself.
+	tick := chart horizontalTick.
 	self assert: chart styler textColor equals: Color black.
 	self assert: tick styler textColor equals: Color black.
 	self assert: chart styler equals: tick styler
@@ -177,11 +175,10 @@ RSChartTest >> testStylerDefault [
 RSChartTest >> testStylerRedLabel [
 	| x tick chart styler |
 	x := -10.0 to: 20.0 count: 100.
-	tick := RSHorizontalTick new.
 	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
-		addDecoration: tick;
 		yourself.
+	tick := chart horizontalTick.
 	styler := RSChartStyler new
 		textColor: Color red.
 	tick styler: styler.
@@ -193,11 +190,10 @@ RSChartTest >> testStylerRedLabel [
 RSChartTest >> testStylerRedTick [
 	| x tick chart styler |
 	x := -10.0 to: 20.0 count: 100.
-	tick := RSHorizontalTick new.
 	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
-		addDecoration: tick;
 		yourself.
+	tick := chart horizontalTick.
 	styler := RSChartStyler new
 		tickColor: Color red.
 	tick styler: styler.
@@ -209,11 +205,10 @@ RSChartTest >> testStylerRedTick [
 RSChartTest >> testStylerRedTickInChart [
 	| x tick chart styler |
 	x := -10.0 to: 20.0 count: 100.
-	tick := RSHorizontalTick new.
 	chart := RSChart new
 		addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
-		addDecoration: tick;
 		yourself.
+	tick := chart horizontalTick.
 	styler := RSChartStyler new
 		tickColor: Color red.
 	chart styler: styler.
@@ -262,6 +257,7 @@ RSChartTest >> testWithWeirdValues [
 	| values g d line c |
 	values := {Float infinity negated. Float infinity negated. 0.30102999566398114. 0.47712125471966244}.
 	g := RSChart new.
+	g removeAllTicks.
 	d := RSLinePlot new y: values.
 	g addPlot: d.
 	g build.
@@ -280,6 +276,7 @@ RSChartTest >> testWithWeirdValuesLine [
 	| values g d line c |
 	values := {Float infinity negated. Float infinity negated. 0.30102999566398114. 0.47712125471966244}.
 	g := RSChart new.
+	g removeAllTicks.
 	d := RSLinePlot new y: values.
 	g addPlot: d.
 	g build.
@@ -305,8 +302,6 @@ RSChartTest >> testWithWeirdValuesLineWithTicks [
 
 	linePlot := RSLinePlot new y: values.
 	chart addPlot: linePlot.
-	chart addDecoration: RSHorizontalTick new.
-	chart addDecoration: RSVerticalTick new.
 	chart build.
 
 	canvas := chart canvas.
@@ -328,7 +323,8 @@ RSChartTest >> testWithWeirdValuesLineWithTicks2 [
 
 	linePlot := RSLinePlot new x: x y: y.
 	chart addPlot: linePlot.
-	chart addDecoration: (RSVerticalTick new doNotUseNiceLabel; yourself).
+	chart verticalTick doNotUseNiceLabel.
+	chart removeHorizontalTicks.
 	chart build.
 
 	self assert: chart minValueX equals: x min.
@@ -355,8 +351,8 @@ RSChartTest >> testYMarker [
 	plot2 x: x y: y.
 	chart addPlot: plot2.
 
-	chart addDecoration: (RSHorizontalTick new doNotUseNiceLabel; yourself).
-	chart addDecoration: RSVerticalTick new asFloat.
+	chart horizontalTick doNotUseNiceLabel.
+	chart verticalTick asFloat.
 
 	marker := RSYMarkerDecoration new.
 	chart addDecoration: marker.

--- a/src/Roassal3-Chart-Tests/RSChartTickTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTickTest.class.st
@@ -13,12 +13,10 @@ RSChartTickTest >> testDoNotUseNiceLabel [
 	c := RSChart new
 		     addPlot: (RSScatterPlot new x: x y: (x raisedTo: 3));
 		     addPlot: (RSLinePlot new x: x y: (x raisedTo: 2));
-		     addDecoration: (RSHorizontalTick new
-				      numberOfTicks: 20;
-				      integer);
-		     addDecoration:
-		     (vertical := RSVerticalTick new integer numberOfTicks: numberOfTicks);
 		     yourself.
+	c horizontalTick numberOfTicks: 20;
+				      integer.
+	vertical := c verticalTick integer numberOfTicks: numberOfTicks.
 	c build.
 	self assert: vertical labels size equals: numberOfTicks
 ]
@@ -39,10 +37,9 @@ RSChartTickTest >> testFromNames [
 
 	chart addPlot: (RSLinePlot new x: x y: y).
 
-	chart addDecoration: (horizontal := RSHorizontalTick new fromNames: dates).
-	chart addDecoration: (RSVerticalTick new
-			 numberOfTicks: 10;
-			 asFloat).
+	horizontal := chart horizontalTick fromNames: dates.
+	chart verticalTick numberOfTicks: 10;
+			 asFloat.
 	chart build.
 	self assert: horizontal labels size equals: dates size
 ]
@@ -57,9 +54,7 @@ RSChartTickTest >> testFromNamesWithEmptyData [
 	chart add: (RSHorizontalBarPlot new
 		x: y y: x;
 		yourself).
-	self should: [ chart add: (RSHorizontalTick new
-		fromNames: dates;
-		yourself) ] raise: Error
+	self should: [ chart horizontalTick fromNames: dates ] raise: Error
 ]
 
 { #category : #tests }
@@ -73,8 +68,7 @@ RSChartTickTest >> testFromNamesWithOneData [
 	chart add: (RSHorizontalBarPlot new
 		x: indices y: values;
 		yourself).
-	chart add: (RSHorizontalTick new
-		fromNames: names;
-		yourself).
+	chart horizontalTick fromNames: names.
+	chart removeVerticalTicks.
 	chart build
 ]

--- a/src/Roassal3-Chart-Tests/RSChartTitleDecorationTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSChartTitleDecorationTest.class.st
@@ -8,6 +8,7 @@ Class {
 RSChartTitleDecorationTest >> testBasic [
 	| c title label |
 	c := RSChart new.
+	c removeAllTicks.
 	title := c title: 'hello'.
 	title styler textColor: Color blue.
 	c build.
@@ -22,6 +23,7 @@ RSChartTitleDecorationTest >> testBasic [
 RSChartTitleDecorationTest >> testBasic2 [
 	| c |
 	c := RSChart new.
+	c removeAllTicks.
 	c addDecoration: (RSChartTitleDecoration new title: 'hello'; fontSize: 20).
 	c build.
 

--- a/src/Roassal3-Chart/RSChart.class.st
+++ b/src/Roassal3-Chart/RSChart.class.st
@@ -198,7 +198,10 @@ RSChart >> initialize [
 
 { #category : #initialization }
 RSChart >> initializeDecorations [
-	self spineDecoration: RSChartSpineDecoration new
+
+	self spineDecoration: RSChartSpineDecoration new.
+	self addDecoration: RSHorizontalTick new.
+	self addDecoration: RSVerticalTick new
 ]
 
 { #category : #inspector }
@@ -323,6 +326,28 @@ RSChart >> padding: aPoint [
 { #category : #accessing }
 RSChart >> plots [
 	^ elements select: #isPlot
+]
+
+{ #category : #removing }
+RSChart >> removeAllTicks [
+	"Remove both horizontal and vertical ticks"
+
+	self removeHorizontalTicks.
+	self removeVerticalTicks
+]
+
+{ #category : #removing }
+RSChart >> removeHorizontalTicks [
+	"Remove horizontal ticks from the chart"
+
+	elements remove: self horizontalTick
+]
+
+{ #category : #removing }
+RSChart >> removeVerticalTicks [
+	"Remove vertical ticks from the chart"
+
+	elements remove: self verticalTick
 ]
 
 { #category : #hooks }

--- a/src/Roassal3-Chart/RSLinePlot.class.st
+++ b/src/Roassal3-Chart/RSLinePlot.class.st
@@ -33,13 +33,11 @@ RSLinePlot class >> y: aCollection [
 { #category : #building }
 RSLinePlot >> buildChart [
 
-	| chartPlot marker markerChar |
+	| chartPlot |
 	chartPlot := RSChart new.
 	chartPlot add: self.
 
 	chartPlot
-		add: RSHorizontalTick new;
-		add: RSVerticalTick new;
 		ylabel: self ylabel;
 		xlabel: self xlabel;
 		extent: 250 @ 200;

--- a/src/Roassal3-Chart/SequenceableCollection.extension.st
+++ b/src/Roassal3-Chart/SequenceableCollection.extension.st
@@ -6,7 +6,5 @@ SequenceableCollection >> rsHistogram [
 	c := RSChart new.
 	plot := RSHistogramPlot new x: self.
 	c addPlot: plot.
-	c addDecoration: RSVerticalTick new.
-	c addDecoration: RSHorizontalTick new.
 	^ c
 ]

--- a/src/Roassal3-SVG-Examples/RSChartExample.extension.st
+++ b/src/Roassal3-SVG-Examples/RSChartExample.extension.st
@@ -15,8 +15,8 @@ RSChartExample >> example13AreaPlot [
 		c := RSChart new.
 		c extent: 500@100.
 		c addPlot: (RSAreaPlot new x: x y1: assoc value key y2: assoc value value).
-		c addDecoration: (RSHorizontalTick new numberOfTicks: 10; asFloat).
-		c addDecoration: (RSVerticalTick new numberOfTicks: 3; asFloat).
+		c horizontalTick numberOfTicks: 10; asFloat.
+		c verticalTick numberOfTicks: 3; asFloat.
 		c ylabel: assoc key.
 		c asShape	].
 	RSVerticalLineLayout on: charts.
@@ -51,8 +51,8 @@ RSChartExample >> example14AreaPlotWithError [
 	c addPlot: (RSLinePlot new x: x y: y_est; color: Color red).
 	c addPlot: (scatter := RSScatterPlot new x: x y: y).
 	scatter color: Color red.
-	c addDecoration: (RSHorizontalTick new numberOfTicks: 10; asFloat).
-	c addDecoration: (RSVerticalTick new numberOfTicks: 3; asFloat).
+	c horizontalTick numberOfTicks: 10; asFloat.
+	c verticalTick numberOfTicks: 3; asFloat.
 	^ c
 ]
 
@@ -68,8 +68,8 @@ RSChartExample >> example15AreaBox [
 	c addPlot: (RSAreaPlot new x: x y1: y1 y2: y2).
 	c addPlot: (RSLinePlot new x: x y: y1; color: Color red; format: 's--').
 	c addPlot: (RSLinePlot new x: x y: y2; color: Color orange; format: 'o--').
-	c addDecoration: (RSHorizontalTick new numberOfTicks: 7; asFloat).
-	c addDecoration: (RSVerticalTick new asFloat).
+	c horizontalTick numberOfTicks: 7; asFloat.
+	c verticalTick asFloat.
 
 	^ c
 ]
@@ -159,10 +159,10 @@ RSChartExample >> example17CLPvsUSD [
 	plot markerEnd: (RSEllipse new size: 10).
 	c addPlot: plot.
 
-	c addDecoration: (horizontal := RSHorizontalTick new fromNames: dates; yourself).
+	horizontal := c horizontalTick fromNames: dates.
 	horizontal configuration fontSize: 4.
 	horizontal useDiagonalLabel.
-	c addDecoration: (RSVerticalTick new numberOfTicks: 10; asFloat).
+	c verticalTick numberOfTicks: 10; asFloat.
 	c title: 'CLP vs USD'.
 	^ c
 ]


### PR DESCRIPTION
Fixes #468 
Ticks are now present by default for charts. Added the ability to remove them when needed, so that charts that didn't have ticks are not forced to have them.
Also adapted methods, tests and examples that added ticks. All tests are green, and all examples should be the same.