### PR TITLE
Log Locator

### DIFF
--- a/src/Roassal3-Chart-Tests/RSTickLocatorTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSTickLocatorTest.class.st
@@ -87,6 +87,136 @@ RSTickLocatorTest >> testLinearLocatorNumberOfTicksIsOk [
 ]
 
 { #category : #tests }
+RSTickLocatorTest >> testLogLocatorBaseIsCorrectlyChanged [
+
+	| locator |
+	locator := RSLogLocator new base: 2.
+
+	self assert: locator base equals: 2
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorDataIsOk [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 0.001 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: (data at: 1) equals: 1/1000.
+	self assert: (data at: 2) equals: 1/100.
+	self assert: (data at: 3) equals: 1/10.
+	self assert: (data at: 4) equals: 1.
+	self assert: (data at: 5) equals: 10
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorDataIsOkStartingAtNegative [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( -1 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: (data at: 1) equals: 1/1000.
+	self assert: (data at: 2) equals: 1/100.
+	self assert: (data at: 3) equals: 1/10.
+	self assert: (data at: 4) equals: 1.
+	self assert: (data at: 5) equals: 10
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorDataIsOkStartingAtZero [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 0 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: (data at: 1) equals: 1/1000.
+	self assert: (data at: 2) equals: 1/100.
+	self assert: (data at: 3) equals: 1/10.
+	self assert: (data at: 4) equals: 1.
+	self assert: (data at: 5) equals: 10
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorDataIsOkWithReversedDomain [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 10 0.001 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: (data at: 1) equals: 1/1000.
+	self assert: (data at: 2) equals: 1/100.
+	self assert: (data at: 3) equals: 1/10.
+	self assert: (data at: 4) equals: 1.
+	self assert: (data at: 5) equals: 10
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorDefaultBaseIs10 [
+
+	| locator |
+	locator := RSLogLocator new.
+
+	self assert: locator base equals: 10
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorNumberOfTicksIsOk [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 0.001 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: data size equals: 5
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorNumberOfTicksIsOkStartingAtNegative [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( -1 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: data size equals: 5
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorNumberOfTicksIsOkStartingAtZero [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 0 10 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: data size equals: 5
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorNumberOfTicksIsOkWithReversedDomain [
+
+	| data |
+	ticks xScale: (NSLogScale new domain: #( 10 0.001 )).
+	ticks locator: RSLogLocator new.
+	data := ticks ticksData.
+
+	self assert: data size equals: 5
+]
+
+{ #category : #tests }
+RSTickLocatorTest >> testLogLocatorRaisesErrorWithNegativeData [
+
+	ticks xScale: (NSLogScale new domain: #( -10 -1 )).
+	ticks locator: RSLogLocator new.
+	self should: [ ticks ticksData ] raise: DomainError
+]
+
+{ #category : #tests }
 RSTickLocatorTest >> testTickLocatorCorrectlyChanged [
 
 	ticks locator: RSLinearLocator new.

--- a/src/Roassal3-Chart/RSChart.class.st
+++ b/src/Roassal3-Chart/RSChart.class.st
@@ -441,7 +441,16 @@ RSChart >> xLog [
 
 { #category : #'public - scales' }
 RSChart >> xRawLog [
-	self xScale: NSScale log
+	
+	self horizontalTick locator: RSLogLocator new.
+	^ self xScale: NSScale log
+]
+
+{ #category : #'public - scales' }
+RSChart >> xRawLog: aNumber [
+	
+	self horizontalTick locator: (RSLogLocator new base: aNumber).
+	^ self xScale: (NSLogScale new base: aNumber) 
 ]
 
 { #category : #'public - scales' }
@@ -491,7 +500,15 @@ RSChart >> yLog [
 { #category : #'public - scales' }
 RSChart >> yRawLog [
 	"ensure all your data and axis do not contains zero"
+	self verticalTick locator: RSLogLocator new.
 	^ self yScale: NSScale log
+]
+
+{ #category : #'public - scales' }
+RSChart >> yRawLog: aNumber [
+	
+	self verticalTick locator: (RSLogLocator new base: aNumber).
+	^ self yScale: (NSLogScale new base: aNumber) 
 ]
 
 { #category : #'public - scales' }

--- a/src/Roassal3-Chart/RSLogLocator.class.st
+++ b/src/Roassal3-Chart/RSLogLocator.class.st
@@ -30,11 +30,6 @@ RSLogLocator >> base: aNumber [
 
 { #category : #generate }
 RSLogLocator >> generateTicks: aScale with: numberOfTicks [
-	"^ (aScale domain first ceiling to: aScale domain last by: 1) select: [
-		  :tick |
-		  | decimalPart |
-		  decimalPart := (tick log: base) fractionPart.
-		  decimalPart < self precision or: 1 - decimalPart < self precision ]"
 
 	| first last power collection tick |
 	first := aScale domain first.

--- a/src/Roassal3-Chart/RSLogLocator.class.st
+++ b/src/Roassal3-Chart/RSLogLocator.class.st
@@ -1,0 +1,76 @@
+"
+<keyClass>
+`RSLogLocator` places ticks in a logarithmic way. A `RSLogLocator` has a base, by default 10, and places a tick at each power of the base (for ex: 0.1, 1, 10, 100, etc).
+However it doesn't rescale the axis.
+
+*Responsibility*: Places logarithmic ticks.
+
+*Collaborators*: `RSLogLocator` is used when rendering ticks.
+"
+Class {
+	#name : #RSLogLocator,
+	#superclass : #RSTickLocator,
+	#instVars : [
+		'base'
+	],
+	#category : #'Roassal3-Chart-Ticks'
+}
+
+{ #category : #generate }
+RSLogLocator >> base [
+
+	^ base
+]
+
+{ #category : #generate }
+RSLogLocator >> base: aNumber [
+
+	base := aNumber
+]
+
+{ #category : #generate }
+RSLogLocator >> generateTicks: aScale with: numberOfTicks [
+	"^ (aScale domain first ceiling to: aScale domain last by: 1) select: [
+		  :tick |
+		  | decimalPart |
+		  decimalPart := (tick log: base) fractionPart.
+		  decimalPart < self precision or: 1 - decimalPart < self precision ]"
+
+	| first last power collection tick |
+	first := aScale domain first.
+	last := aScale domain last.
+
+	last < first ifTrue: [
+		| temp |
+		temp := last.
+		last := first.
+		first := temp ].
+
+	last <= 0 ifTrue: [
+		^ DomainError signal: 'Data has no positive value' ].
+
+	first <= 0 ifTrue: [ first := self smallestIndex ].
+	power := (first log: base) rounded.
+	collection := OrderedCollection new.
+	tick := base ** power.
+
+	[ tick <= last ] whileTrue: [
+		collection add: tick.
+		power := power + 1.
+		tick := base ** power ].
+
+	^ collection
+]
+
+{ #category : #initialization }
+RSLogLocator >> initialize [
+
+	super initialize.
+	base := 10
+]
+
+{ #category : #stepping }
+RSLogLocator >> smallestIndex [
+
+	^ 10**(-3)
+]


### PR DESCRIPTION
Added another tick locator: `RSLogLocator`. It places ticks in a logarithmic way.
Modified `xRawLog` and `yRawLog` methods so that they automatically use a `RSLogLocator` when rescaling their respective axis.
Added `xRawLog:` and `yRawLog:` for log in another base than 10.
Here is an example:
```SmallTalk
x1 := 0 to: 1 by: 0.001.
x2 := 1.1 to: 100 by: 0.1.
x := x1 asOrderedCollection  addAll: x2 asOrderedCollection ; yourself.
y := x log.
chart := RSChart new.
chart addPlot: (RSLinePlot new x: x y: y).
chart xRawLog.
chart show
```
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/cff6f374-705b-46af-b746-664a0882f36f)
