### PR TITLE
Improved RSHistogramPlot

### DIFF
--- a/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSHistogramExample.class.st
@@ -173,15 +173,13 @@ RSHistogramExample >> example09BinsCollection [
 { #category : #examples }
 RSHistogramExample >> example10Objects [
 	<script: 'self new example10Objects open'>
-	| values c plot classes tick map |
+	| c plot classes tick |
 	classes := Collection withAllSubclasses.
 
-	values := classes collect: #linesOfCode.
-	map := Dictionary newFromKeys: classes andValues: values.
 	c := RSChart new.
 	c padding: 10@10.
 	c extent: 300@200.
-	plot := RSHistogramPlot new x: values.
+	plot := RSHistogramPlot of: classes on: #linesOfCode.
 	plot bins: (0 to: 1000 by: 20) , {1000. 2000. 3000 }.
 
 	tick := c verticalTick.
@@ -191,19 +189,12 @@ RSHistogramExample >> example10Objects [
 	c add: plot.
 	c build.
 
-	plot bars do: [ :bar | | range classesToShow |
-		range := bar model key.
-		classesToShow := classes
-			select: [ :cls | (map at: cls)
-				between: range key and: range value ].
-		bar model: classesToShow.
-		 ].
 	plot bars @ (RSPopup text: [:classesToShow |
 		String streamContents: [ :stream |
 			classesToShow do: [ :cls |
 				cls printOn: stream.
 				stream << ' LOC: '.
-				(map at: cls) printOn: stream ]
+				(plot map at: cls) printOn: stream ]
 			separatedBy: [ stream cr ].
 			]
 		]).

--- a/src/Roassal3-Chart-Tests/RSHistogramPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSHistogramPlotTest.class.st
@@ -1,13 +1,22 @@
 Class {
 	#name : #RSHistogramPlotTest,
 	#superclass : #TestCase,
+	#instVars : [
+		'c'
+	],
 	#category : #'Roassal3-Chart-Tests-Core'
 }
 
+{ #category : #running }
+RSHistogramPlotTest >> setUp [
+
+	super setUp.
+	c := RSChart new
+]
+
 { #category : #tests }
 RSHistogramPlotTest >> testBasic [
-	| c values plot |
-	c := RSChart new.
+	| values plot |
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values).
 	c build.
@@ -18,8 +27,7 @@ RSHistogramPlotTest >> testBasic [
 
 { #category : #tests }
 RSHistogramPlotTest >> testBinSize [
-	| c values plot size |
-	c := RSChart new.
+	| values plot size |
 	values := (1 to: 100) shuffled.
 	c addPlot: (plot := RSHistogramPlot new x: values; binSize: 30).
 	c build.
@@ -29,8 +37,7 @@ RSHistogramPlotTest >> testBinSize [
 
 { #category : #tests }
 RSHistogramPlotTest >> testBins [
-	| c values plot |
-	c := RSChart new.
+	| values plot |
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values; numberOfBins: 2).
 	self deny: plot bins isNil.
@@ -44,8 +51,7 @@ RSHistogramPlotTest >> testBins [
 
 { #category : #tests }
 RSHistogramPlotTest >> testBinsCollection [
-	| c values plot bins |
-	c := RSChart new.
+	| values plot bins |
 	bins := #(1 5 8 10).
 	values := #(1 2 3 4 5 6 7 8 9 10).
 	c addPlot: (plot := RSHistogramPlot new x: values; bins: bins).
@@ -59,8 +65,7 @@ RSHistogramPlotTest >> testBinsCollection [
 
 { #category : #tests }
 RSHistogramPlotTest >> testBinsStrat [
-	| c values plot strategy size |
-	c := RSChart new.
+	| values plot strategy size |
 	strategy := RSSturgesBinning new.
 	values := (1 to: 100) shuffled.
 	c addPlot: (plot := RSHistogramPlot new x: values; binningStrategy: strategy).
@@ -68,4 +73,52 @@ RSHistogramPlotTest >> testBinsStrat [
 	size := (strategy computeNumberOfBinsFor: values).
 	self assert: plot bars size equals: size.
 	self assert: plot xValues equals: (1 to: 100 by: 99/size)
+]
+
+{ #category : #tests }
+RSHistogramPlotTest >> testCollectDataOfOn [
+
+	| col plot |
+	col := 1 to: 10.
+	plot := RSHistogramPlot new.
+	
+	plot collectDataOf: col on: [ :e | e % 4 ]; numberOfBins: 4.
+	
+	self assert: plot x equals: #(0 0 1 1 1 2 2 2 3 3).
+	self assert: plot map equals: (Dictionary newFrom: { 1->1. 2->2. 3->3. 4->0. 5->1. 6->2. 7->3. 8->0. 9->1. 10->2 })
+]
+
+{ #category : #tests }
+RSHistogramPlotTest >> testModelWithCollectedData [
+
+	| col plot bars |
+	col := 1 to: 10.
+	plot := RSHistogramPlot new.
+	
+	plot collectDataOf: col on: [ :e | e % 4 ]; numberOfBins: 4.
+	c addPlot: plot.
+	c build.
+	bars := plot bars.
+	
+	self assert: (plot bars at:1) model sorted equals: #(4 8).
+	self assert: (plot bars at:2) model sorted equals: #(1 5 9).
+	self assert: (plot bars at:3) model sorted equals: #(2 6 10).
+	self assert: (plot bars at:4) model sorted equals: #(3 7).
+]
+
+{ #category : #tests }
+RSHistogramPlotTest >> testModelWithRawValues [
+
+	| plot bars |
+	plot := RSHistogramPlot new.
+	
+	plot x: #(0 1 3 3 1 1); bins: (0 to: 4).
+	c addPlot: plot.
+	c build.
+	bars := plot bars.
+	
+	self assert: (plot bars at:1) model equals: 0->1->1.
+	self assert: (plot bars at:2) model equals: 1->2->3.
+	self assert: (plot bars at:3) model equals: 2->3->0.
+	self assert: (plot bars at:4) model equals: 3->4->2.
 ]

--- a/src/Roassal3-Chart/RSHistogramPlot.class.st
+++ b/src/Roassal3-Chart/RSHistogramPlot.class.st
@@ -23,6 +23,7 @@ Class {
 	#name : #RSHistogramPlot,
 	#superclass : #RSAbstractPlot,
 	#instVars : [
+		'map',
 		'x',
 		'bins',
 		'bars',
@@ -30,6 +31,12 @@ Class {
 	],
 	#category : #'Roassal3-Chart-Plots'
 }
+
+{ #category : #'instance creation' }
+RSHistogramPlot class >> of: aCollection on: aBloc [
+
+	^ self new collectDataOf: aCollection on: aBloc
+]
 
 { #category : #accessing }
 RSHistogramPlot >> bars [
@@ -66,6 +73,15 @@ RSHistogramPlot >> bins: aCollection [
 	self binningStrategy: (RSFixedBinning new
 		bins: aCollection;
 		yourself)
+]
+
+{ #category : #enumerating }
+RSHistogramPlot >> collectDataOf: aCollection on: aBloc [
+
+	x := aCollection collect: aBloc.
+	map := Dictionary newFromKeys: aCollection andValues: x.
+	x := x sorted.
+	self computeXYValues
 ]
 
 { #category : #private }
@@ -114,6 +130,31 @@ RSHistogramPlot >> initialize [
 ]
 
 { #category : #accessing }
+RSHistogramPlot >> map [
+
+	^ map
+]
+
+{ #category : #accessing }
+RSHistogramPlot >> map: aMap [
+
+	map := aMap
+]
+
+{ #category : #accessing }
+RSHistogramPlot >> model: anArray [
+
+	| toShow xVal xVal2 yVal |
+	xVal := anArray first.
+	xVal2 := anArray second.
+	yVal := anArray last.
+
+	map ifNil: [ ^ xVal -> xVal2 -> yVal ].
+	^ toShow := map keys select: [ :e |
+		          (map at: e) between: xVal and: xVal2 ]
+]
+
+{ #category : #accessing }
 RSHistogramPlot >> numberOfBins [
 	^ self binningStrategy numberOfBins
 ]
@@ -126,20 +167,26 @@ RSHistogramPlot >> numberOfBins: aNumber [
 
 { #category : #rendering }
 RSHistogramPlot >> renderIn: canvas [
+
 	bars := yValues collectWithIndex: [ :yVal :index |
-		| rect xVal xVal2 |
-		xVal := xValues at: index.
-		xVal2 := xValues at: index +1.
-		rect := Rectangle
-			origin: (self scalePoint: xVal @ yVal)
-			corner: (self scalePoint: xVal2 @ 0).
-		self shape copy
-			model: (xVal->xVal2) -> yVal;
-			color: self computeColor;
-			fromRectangle: rect;
-			yourself ].
+		        | rect xVal xVal2 |
+		        xVal := xValues at: index.
+		        xVal2 := xValues at: index + 1.
+		        rect := Rectangle
+			                origin: (self scalePoint: xVal @ yVal)
+			                corner: (self scalePoint: xVal2 @ 0).
+		        self shape copy
+			        model: (self model: { xVal. xVal2. yVal });
+			        color: self computeColor;
+			        fromRectangle: rect;
+			        yourself ].
 	bars := bars asGroup.
 	canvas addAll: bars
+]
+
+{ #category : #accessing }
+RSHistogramPlot >> x [
+	^ x
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Improved `RSHistogramPlot`. The main idea is to make the creation of histograms such as the example 10 of `RSHistogramExample` easier and shorter.
At declaration of a `RSHistogramPlot`, you can give it a collection and a bloc, so it will `collect:` using the bloc on the collection, create a `Dictionary` with the associations of elements from the collection and their value from the `collect:`. Then the model for the bars will be the elements of the collection corresponding to the values in the bar, rather than associations. Check `example10Objects` for an example.
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/7ff072b3-1efa-4d63-b0bf-d7676b3133b1)
