### PR TITLE
Boxplot notch

### DIFF
--- a/src/Roassal3-Chart-Tests/RSBoxPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSBoxPlotTest.class.st
@@ -2,9 +2,127 @@ Class {
 	#name : #RSBoxPlotTest,
 	#superclass : #RSTest,
 	#instVars : [
-		'x',
-		'y',
-		'plot'
+		'plot',
+		'y'
 	],
 	#category : #'Roassal3-Chart-Tests-Base'
 }
+
+{ #category : #running }
+RSBoxPlotTest >> setUp [
+
+	super setUp.
+	plot := RSBoxPlot new.
+	y := {
+		     { 1. 2 }.
+		     { 3. 4 } }.
+	plot y: y
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidenceIntervalIsOk [
+
+	| median iqr |
+	y := {
+		     { 1. 2. 3. 4. 5 }.
+		     { 1 } }.
+	plot y: y.
+	plot notch: true.
+	plot build.
+	median := (plot boxAndWhisker at: 1) at: 4.
+	iqr := ((plot boxAndWhisker at: 1) at: 5) - ((plot boxAndWhisker at: 1) at: 3).
+
+	self assert: ((plot boxAndWhisker at: 1) at: 8) equals: median + (1.57 * iqr/(5 sqrt)).
+	self assert: ((plot boxAndWhisker at: 1) at: 9) equals: median - (1.57 * iqr/(5 sqrt))
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidenceIntervalMaxIsGreaterThanQuartile3 [
+
+	| confidenceIntervalMax quartile3 |
+	y := {
+		     { 1. 2. 3. 4. 5 }.
+		     { 1 } }.
+	plot y: y.
+	plot notch: true.
+	plot build.
+	confidenceIntervalMax := (plot boxAndWhisker at: 1) at: 8.
+	quartile3 := (plot boxAndWhisker at: 1) at: 5.
+
+	self assert: confidenceIntervalMax > quartile3
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidenceIntervalMaxIsLesserThanQuartile3 [
+
+	| confidenceIntervalMax quartile3 |
+	y := {
+		     { 1. 2. 3. 4. 5. 1. 2. 3. 4. 5. 1. 2. 3. 4. 5 }.
+		     { 1 } }.
+	plot y: y.
+	plot notch: true.
+	plot build.
+	confidenceIntervalMax := (plot boxAndWhisker at: 1) at: 8.
+	quartile3 := (plot boxAndWhisker at: 1) at: 5.
+
+	self assert: confidenceIntervalMax < quartile3
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidenceIntervalMinIsGreaterThanQuartile1 [
+
+	| confidenceIntervalMin quartile1 |
+	y := {
+		     { 1. 2. 3. 4. 5. 1. 2. 3. 4. 5. 1. 2. 3. 4. 5 }.
+		     { 1 } }.
+	plot y: y.
+	plot notch: true.
+	plot build.
+	confidenceIntervalMin := (plot boxAndWhisker at: 1) at: 9.
+	quartile1 := (plot boxAndWhisker at: 1) at: 3.
+
+	self assert: confidenceIntervalMin > quartile1
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidenceIntervalMinIsLesserThanQuartile1 [
+
+	| confidenceIntervalMin quartile1 |
+	y := {
+		     { 1. 2. 3. 4. 5 }.
+		     { 1 } }.
+	plot y: y.
+	plot notch: true.
+	plot build.
+	confidenceIntervalMin := (plot boxAndWhisker at: 1) at: 9.
+	quartile1 := (plot boxAndWhisker at: 1) at: 3.
+
+	self assert: confidenceIntervalMin < quartile1
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testConfidencePercentageIsCorrectlyChanged [
+
+	plot confidencePercentage: 99.
+	plot build.
+
+	self assert: plot confidencePercentage equals: 99
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testDefaultConfidencePercentageIs95 [
+
+	plot y: {
+			{ 1. 2 }.
+			{ 3. 4 } }.
+			
+	self assert: plot confidencePercentage equals: 95
+]
+
+{ #category : #tests }
+RSBoxPlotTest >> testNotchBasic [
+
+	plot notch: true.
+	
+	plot build
+]

--- a/src/Roassal3-Chart-Tests/RSBoxPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSBoxPlotTest.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #RSBoxPlotTest,
+	#superclass : #RSTest,
+	#instVars : [
+		'x',
+		'y',
+		'plot'
+	],
+	#category : #'Roassal3-Chart-Tests-Base'
+}

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -84,6 +84,12 @@ RSBoxPlot >> beforeRenderingIn: aChart [
 ]
 
 { #category : #private }
+RSBoxPlot >> boxAndWhisker [
+
+	^ boxAndWhisker
+]
+
+{ #category : #private }
 RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 	"Converts a 2D collection of data points into the poisition of the 1 and 3 quartile, the whiskers, and outlieing points.
 
@@ -258,6 +264,12 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 RSBoxPlot >> confidencePercentage [
 
 	^ confidencePercentage
+]
+
+{ #category : #accessing }
+RSBoxPlot >> confidencePercentage: aPercentage [
+
+	confidencePercentage := aPercentage
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -171,14 +171,14 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 	confidenceIntervalOrigin := self scalePoint: confidenceIntervalPoint.
 	confidenceIntervalCorner := origin x @ (yScale scale: confidenceIntervalZero ).
 	
-	confidenceIntervalTopLeft := confidenceIntervalOrigin + offset - (0.5*sizeOffset).
-	confidenceIntervalBottomRight := confidenceIntervalCorner + offset + (0.5*sizeOffset).
+	confidenceIntervalTopLeft := confidenceIntervalOrigin + offset - sizeOffset.
+	confidenceIntervalBottomRight := confidenceIntervalCorner + offset + sizeOffset.
 
 	
 	^{ 	self shape copy
 		model: (self modelFor: aPoint);
 		color: self computeColor;
-		borderColor: Color black;
+		"borderColor: Color black;"
 		fromRectangle: (Rectangle origin: topLeft corner: bottomRight );
 		yourself.
 		RSLine new
@@ -189,15 +189,16 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 			startPoint: center @ origin y;
 			endPoint: topWhiskerExtent;
 			color: Color black.
-		self shape copy
-		model: (self modelFor: confidenceIntervalPoint);
-		color: self computeColor;
-		borderColor: Color black;
-		fromRectangle: (Rectangle origin: confidenceIntervalTopLeft corner: confidenceIntervalBottomRight ).
 		RSLine new
 			startPoint: (topLeft x  @ (yScale scale: (boxAndWhis at: 4)));
 			endPoint: (bottomRight x @(yScale scale: (boxAndWhis at: 4)));
-			color: Color black },
+			color: Color black.
+		RSPolygon new
+			points: { confidenceIntervalTopLeft - (5@0) . (confidenceIntervalTopLeft x - 5) @ confidenceIntervalBottomRight y . (confidenceIntervalTopLeft x + (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
+			color: Color white.
+		RSPolygon new
+			points: { confidenceIntervalBottomRight + (5@0) . (confidenceIntervalBottomRight x + 5) @ confidenceIntervalTopLeft y . (confidenceIntervalBottomRight x - (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
+			color: Color white },
 		lowerOutliers,
 		upperOutliers
 ]

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -22,6 +22,29 @@ p ylabel: 'Y Axis'.
 p title: 'Box Plot'.
 p openOnce.
 ```
+
+The plot can be notched to represent the confidence interval around the median. There is 3 possible percentages for the interval: 90%, 95% (default one) and 99%.
+Please note that the values used for 90% and 99% may not be exact due to a lack of data about it, but it is correct for 95%.
+
+```
+| y p1 p2 c size |
+
+y :=  { {  1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. } . { 1. 2. 3. 4. 5. 6. 7.  } }.
+
+size := 50.
+
+c := RSCompositeChart new.
+p1 := RSBoxPlot new.
+p1 y: y.
+p1 notch: true.
+p1 barSize: size.
+p1 barOffset: size * -0.55.
+p2 := RSBoxPlot new y: y.
+p2 barSize: size.
+p2 barOffset: size * 0.55.
+c add: p1; add: p2.
+c open
+```
 "
 Class {
 	#name : #RSBoxPlot,

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -32,7 +32,9 @@ Class {
 		'gapRatio',
 		'barOffset',
 		'boxAndWhisker',
-		'notched'
+		'notched',
+		'notchFactors',
+		'confidencePercentage'
 	],
 	#category : #'Roassal3-Chart-Core'
 }
@@ -95,7 +97,7 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 	7. An array of the upper outlying data
 	"
 	boxAndWhisker := aCollection collect: [ :i |
-		|iSort quartile1 quartile3 minVal maxVal bottomWhiskerExtent topWhiskerExtent iqr bottomOutliers topOutliers confidenceIntervalMax confidenceIntervalMin |
+		|iSort quartile1 quartile3 minVal maxVal bottomWhiskerExtent topWhiskerExtent iqr bottomOutliers topOutliers confidenceIntervalMax confidenceIntervalMin factor |
 
 		iSort := i asSortedCollection .
 
@@ -105,9 +107,12 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 		quartile3 := self quantile: 0.75 for: iSort.
 		iqr := quartile3 - quartile1 .
 		"95% confidence interval around the median"
-		confidenceIntervalMax := iSort median + (1.57 * iqr/(iSort size sqrt)).
-		confidenceIntervalMin  := iSort median - (1.57 * iqr/(iSort size sqrt)).
-		
+		factor := self notchFactorFor: confidencePercentage.
+		confidenceIntervalMax := iSort median + (factor * iqr/(iSort size sqrt)).
+		confidenceIntervalMin  := iSort median - (factor * iqr/(iSort size sqrt)).
+		Transcript show: '2 '; show: confidencePercentage ; cr.
+		"Transcript show: '1 '; show: confidenceIntervalMax ; cr.
+		Transcript show: '2 '; show: confidenceIntervalMin; cr."
 		bottomWhiskerExtent := quartile1 - (iqr * 1.5).
 		bottomWhiskerExtent <= minVal
 			ifTrue: [ bottomWhiskerExtent := minVal. bottomOutliers := Array new ]
@@ -252,6 +257,18 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 ]
 
 { #category : #accessing }
+RSBoxPlot >> confidencePercentage [
+
+	^ confidencePercentage
+]
+
+{ #category : #accessing }
+RSBoxPlot >> confidencePercentage: aPercentage [
+
+	confidencePercentage := aPercentage
+]
+
+{ #category : #accessing }
 RSBoxPlot >> createdShapes [
 	^ bars
 ]
@@ -282,8 +299,14 @@ RSBoxPlot >> gapRatio: aNumber [
 
 { #category : #initialization }
 RSBoxPlot >> initialize [
+
 	super initialize.
 	notched := false.
+	notchFactors := Dictionary newFrom: {
+			                (90 -> 1.28).
+			                (95 -> 1.57).
+			                (99 -> 1.81) }.
+	confidencePercentage := 95.
 	self
 		gapRatio: 0.1;
 		barOffset: 0
@@ -317,6 +340,18 @@ RSBoxPlot >> notch: aBool [
 	notched := aBool
 ]
 
+{ #category : #accessing }
+RSBoxPlot >> notchFactorFor: aValue [
+
+	^ notchFactors at: aValue
+]
+
+{ #category : #accessing }
+RSBoxPlot >> notchFactors [
+
+	^ notchFactors
+]
+
 { #category : #'math functions' }
 RSBoxPlot >> quantile: aProbability for: aSortedCollection [
 	"returns the expected quantile only, if I use my standard initialization method"
@@ -346,6 +381,7 @@ RSBoxPlot >> renderIn: canvas [
 	| index |
 	super renderIn: canvas.
 	self checkAssertion.
+	self computeBoxAndWhiskerExtent: yValues.
 	index := 1.
 	bars := xValues flatCollect: [ :xt |
 		| bar |
@@ -353,11 +389,4 @@ RSBoxPlot >> renderIn: canvas [
 		index := index + 1.
 		bar ] as: RSGroup.
 	canvas addAll: bars
-]
-
-{ #category : #public }
-RSBoxPlot >> x: aCollection y: aCollection2 [
-	xValues := aCollection.
-	yValues := aCollection2.
-	self computeBoxAndWhiskerExtent: aCollection2
 ]

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -94,7 +94,7 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 	7. An array of the upper outlying data
 	"
 	boxAndWhisker := aCollection collect: [ :i |
-		|iSort quartile1 quartile3 minVal maxVal bottomWhiskerExtent topWhiskerExtent iqr bottomOutliers topOutliers |
+		|iSort quartile1 quartile3 minVal maxVal bottomWhiskerExtent topWhiskerExtent iqr bottomOutliers topOutliers confidenceIntervalMax confidenceIntervalMin |
 
 		iSort := i asSortedCollection .
 
@@ -103,7 +103,10 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 		quartile1 := self quantile: 0.25 for: iSort.
 		quartile3 := self quantile: 0.75 for: iSort.
 		iqr := quartile3 - quartile1 .
-
+		"95% confidence interval around the median"
+		confidenceIntervalMax := iSort median + (1.57 * iqr/(iSort size sqrt)).
+		confidenceIntervalMin  := iSort median - (1.57 * iqr/(iSort size sqrt)).
+		
 		bottomWhiskerExtent := quartile1 - (iqr * 1.5).
 		bottomWhiskerExtent <= minVal
 			ifTrue: [ bottomWhiskerExtent := minVal. bottomOutliers := Array new ]
@@ -114,7 +117,7 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 			ifTrue: [ topWhiskerExtent := maxVal. topOutliers := Array new ]
 			ifFalse: [ topOutliers := i select: [ :j | j > topWhiskerExtent  ] ].
 
-		{ bottomOutliers . bottomWhiskerExtent . quartile1. iSort median. quartile3. topWhiskerExtent . topOutliers  }
+		{ bottomOutliers . bottomWhiskerExtent . quartile1. iSort median. quartile3. topWhiskerExtent . topOutliers . confidenceIntervalMax . confidenceIntervalMin }
 	]
 ]
 
@@ -128,7 +131,7 @@ RSBoxPlot >> computeOutliersFor: points at: xValue [
 		| newPoint |
 		newPoint := xValue @ (yScale scale: i).
 		RSEllipse new
-				radius: 2;
+				radius: 2.5;
 				color: self computeColor;
 				translateTo: newPoint .
 	]
@@ -137,7 +140,7 @@ RSBoxPlot >> computeOutliersFor: points at: xValue [
 { #category : #rendering }
 RSBoxPlot >> computeRectagleAndLinesFor: index [
    "Convert the box and whisker extents to their positions in the plot using the scale"
-	| lowerOutliers upperOutliers boxAndWhis origin sizeOffset offset zero aPoint topLeft bottomRight bottomWhiskerExtent topWhiskerExtent corner center |
+	| lowerOutliers upperOutliers boxAndWhis origin sizeOffset offset zero aPoint topLeft bottomRight bottomWhiskerExtent topWhiskerExtent corner center confidenceIntervalPoint confidenceIntervalZero confidenceIntervalOrigin confidenceIntervalCorner confidenceIntervalTopLeft confidenceIntervalBottomRight |
 
 	boxAndWhis := boxAndWhisker at: index.
 	aPoint := (xValues at: index) @ (boxAndWhis at: 5).
@@ -161,22 +164,40 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 
 	bottomWhiskerExtent := center @ (yScale scale: (boxAndWhis at: 2)).
 	topWhiskerExtent := center @ (yScale scale: (boxAndWhis at: 6)).
+	
+	"For the 95% confidence interval around the median"
+	confidenceIntervalPoint := (xValues at: index) @ (boxAndWhis at: 8).
+	confidenceIntervalZero := boxAndWhis at: 9.
+	confidenceIntervalOrigin := self scalePoint: confidenceIntervalPoint.
+	confidenceIntervalCorner := origin x @ (yScale scale: confidenceIntervalZero ).
+	
+	confidenceIntervalTopLeft := confidenceIntervalOrigin + offset - (0.5*sizeOffset).
+	confidenceIntervalBottomRight := confidenceIntervalCorner + offset + (0.5*sizeOffset).
 
-
+	
 	^{ 	self shape copy
 		model: (self modelFor: aPoint);
 		color: self computeColor;
+		borderColor: Color black;
 		fromRectangle: (Rectangle origin: topLeft corner: bottomRight );
 		yourself.
 		RSLine new
-			startPoint: (topLeft x  @ (yScale scale: (boxAndWhis at: 4)));
-			endPoint: (bottomRight x @(yScale scale: (boxAndWhis at: 4))).
-		RSLine new
 			startPoint: center @ corner y;
-			endPoint: bottomWhiskerExtent .
+			endPoint: bottomWhiskerExtent;
+			color: Color black.
 		RSLine new
 			startPoint: center @ origin y;
-			endPoint: topWhiskerExtent},
+			endPoint: topWhiskerExtent;
+			color: Color black.
+		self shape copy
+		model: (self modelFor: confidenceIntervalPoint);
+		color: self computeColor;
+		borderColor: Color black;
+		fromRectangle: (Rectangle origin: confidenceIntervalTopLeft corner: confidenceIntervalBottomRight ).
+		RSLine new
+			startPoint: (topLeft x  @ (yScale scale: (boxAndWhis at: 4)));
+			endPoint: (bottomRight x @(yScale scale: (boxAndWhis at: 4)));
+			color: Color black },
 		lowerOutliers,
 		upperOutliers
 ]

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -175,29 +175,34 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 	confidenceIntervalBottomRight := confidenceIntervalCorner + offset + sizeOffset.
 
 	
-	^{ 	self shape copy
+	^{ "the main box"	
+		self shape copy
 		model: (self modelFor: aPoint);
 		color: self computeColor;
-		"borderColor: Color black;"
 		fromRectangle: (Rectangle origin: topLeft corner: bottomRight );
 		yourself.
+		"the bottom whisker"
 		RSLine new
 			startPoint: center @ corner y;
 			endPoint: bottomWhiskerExtent;
 			color: Color black.
+		"the top whisker"
 		RSLine new
 			startPoint: center @ origin y;
 			endPoint: topWhiskerExtent;
 			color: Color black.
+		"the median line"
 		RSLine new
 			startPoint: (topLeft x  @ (yScale scale: (boxAndWhis at: 4)));
 			endPoint: (bottomRight x @(yScale scale: (boxAndWhis at: 4)));
 			color: Color black.
+		"the left notch triangle"
 		RSPolygon new
-			points: { confidenceIntervalTopLeft - (5@0) . (confidenceIntervalTopLeft x - 5) @ confidenceIntervalBottomRight y . (confidenceIntervalTopLeft x + (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
+			points: { confidenceIntervalTopLeft - (0.5@0) . (confidenceIntervalTopLeft x - 0.5) @ confidenceIntervalBottomRight y . (confidenceIntervalTopLeft x + (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
 			color: Color white.
+		"the right notch triangle"
 		RSPolygon new
-			points: { confidenceIntervalBottomRight + (5@0) . (confidenceIntervalBottomRight x + 5) @ confidenceIntervalTopLeft y . (confidenceIntervalBottomRight x - (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
+			points: { confidenceIntervalBottomRight + (0.5@0) . (confidenceIntervalBottomRight x + 0.5) @ confidenceIntervalTopLeft y . (confidenceIntervalBottomRight x - (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
 			color: Color white },
 		lowerOutliers,
 		upperOutliers

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -31,7 +31,8 @@ Class {
 		'bars',
 		'gapRatio',
 		'barOffset',
-		'boxAndWhisker'
+		'boxAndWhisker',
+		'notched'
 	],
 	#category : #'Roassal3-Chart-Core'
 }
@@ -122,6 +123,64 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 ]
 
 { #category : #rendering }
+RSBoxPlot >> computeMainBoxWith: values [
+
+	| boxAndWhis topLeft bottomRight confidenceIntervalTopLeft confidenceIntervalBottomRight sizeOffset aPoint |
+	boxAndWhis := values at: 1.
+	topLeft := values at: 2.
+	bottomRight := values at: 3.
+	confidenceIntervalTopLeft := values at: 4.
+	confidenceIntervalBottomRight := values at: 5.
+	sizeOffset := values at: 6.
+	aPoint := values at: 7.
+
+	^ notched
+		  ifTrue: [
+			  RSPolygon new
+				  points: {
+						  topLeft.
+						  (bottomRight x @ topLeft y).
+						  (confidenceIntervalBottomRight x @ confidenceIntervalTopLeft y).
+						  (confidenceIntervalBottomRight x - (0.5 * sizeOffset x) @ (yScale scale: (boxAndWhis at: 4))).
+						  confidenceIntervalBottomRight.
+						  bottomRight.
+						  (topLeft x @ bottomRight y).
+						  (confidenceIntervalTopLeft x @ confidenceIntervalBottomRight y).
+						  (confidenceIntervalTopLeft x + (0.5 * sizeOffset x) @ (yScale scale: (boxAndWhis at: 4))).
+						  confidenceIntervalTopLeft };
+				  color: self computeColor ]
+		  ifFalse: [
+			  self shape copy
+				  model: (self modelFor: aPoint);
+				  color: self computeColor;
+				  fromRectangle: (Rectangle origin: topLeft corner: bottomRight) ]
+]
+
+{ #category : #rendering }
+RSBoxPlot >> computeMedianLineWith: values [
+
+	| boxAndWhis topLeft bottomRight confidenceIntervalTopLeft confidenceIntervalBottomRight sizeOffset |
+	boxAndWhis := values at: 1.
+	topLeft := values at: 2.
+	bottomRight := values at: 3.
+	confidenceIntervalTopLeft := values at: 4.
+	confidenceIntervalBottomRight := values at: 5.
+	sizeOffset := values at: 6.
+
+	^ notched
+		  ifTrue: [
+			  RSLine new
+				  startPoint:
+					  confidenceIntervalTopLeft x + (0.5 * sizeOffset x) @ (yScale scale: (boxAndWhis at: 4));
+				  endPoint:
+					  confidenceIntervalBottomRight x - (0.5 * sizeOffset x) @ (yScale scale: (boxAndWhis at: 4)) ]
+		  ifFalse: [
+			  RSLine new
+				  startPoint: topLeft x @ (yScale scale: (boxAndWhis at: 4));
+				  endPoint: bottomRight x @ (yScale scale: (boxAndWhis at: 4)) ]
+]
+
+{ #category : #rendering }
 RSBoxPlot >> computeOutliersFor: points at: xValue [
 
 	"Translates a collection of points to the plot coordinates and returns a collection of RSEllipse"
@@ -140,7 +199,7 @@ RSBoxPlot >> computeOutliersFor: points at: xValue [
 { #category : #rendering }
 RSBoxPlot >> computeRectagleAndLinesFor: index [
    "Convert the box and whisker extents to their positions in the plot using the scale"
-	| lowerOutliers upperOutliers boxAndWhis origin sizeOffset offset zero aPoint topLeft bottomRight bottomWhiskerExtent topWhiskerExtent corner center confidenceIntervalPoint confidenceIntervalZero confidenceIntervalOrigin confidenceIntervalCorner confidenceIntervalTopLeft confidenceIntervalBottomRight |
+	| lowerOutliers upperOutliers boxAndWhis origin sizeOffset offset zero aPoint topLeft bottomRight bottomWhiskerExtent topWhiskerExtent corner center confidenceIntervalPoint confidenceIntervalZero confidenceIntervalOrigin confidenceIntervalCorner confidenceIntervalTopLeft confidenceIntervalBottomRight values |
 
 	boxAndWhis := boxAndWhisker at: index.
 	aPoint := (xValues at: index) @ (boxAndWhis at: 5).
@@ -174,36 +233,20 @@ RSBoxPlot >> computeRectagleAndLinesFor: index [
 	confidenceIntervalTopLeft := confidenceIntervalOrigin + offset - sizeOffset.
 	confidenceIntervalBottomRight := confidenceIntervalCorner + offset + sizeOffset.
 
+	values := { boxAndWhis . topLeft . bottomRight . confidenceIntervalTopLeft . confidenceIntervalBottomRight . sizeOffset . aPoint } asOrderedCollection.
 	
 	^{ "the main box"	
-		self shape copy
-		model: (self modelFor: aPoint);
-		color: self computeColor;
-		fromRectangle: (Rectangle origin: topLeft corner: bottomRight );
-		yourself.
+		self computeMainBoxWith: values .
 		"the bottom whisker"
 		RSLine new
 			startPoint: center @ corner y;
-			endPoint: bottomWhiskerExtent;
-			color: Color black.
+			endPoint: bottomWhiskerExtent.
 		"the top whisker"
 		RSLine new
 			startPoint: center @ origin y;
-			endPoint: topWhiskerExtent;
-			color: Color black.
+			endPoint: topWhiskerExtent.
 		"the median line"
-		RSLine new
-			startPoint: (topLeft x  @ (yScale scale: (boxAndWhis at: 4)));
-			endPoint: (bottomRight x @(yScale scale: (boxAndWhis at: 4)));
-			color: Color black.
-		"the left notch triangle"
-		RSPolygon new
-			points: { confidenceIntervalTopLeft - (0.5@0) . (confidenceIntervalTopLeft x - 0.5) @ confidenceIntervalBottomRight y . (confidenceIntervalTopLeft x + (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
-			color: Color white.
-		"the right notch triangle"
-		RSPolygon new
-			points: { confidenceIntervalBottomRight + (0.5@0) . (confidenceIntervalBottomRight x + 0.5) @ confidenceIntervalTopLeft y . (confidenceIntervalBottomRight x - (0.5*(sizeOffset x))) @ (yScale scale: (boxAndWhis at: 4)) };
-			color: Color white },
+		self computeMedianLineWith: values },
 		lowerOutliers,
 		upperOutliers
 ]
@@ -240,6 +283,7 @@ RSBoxPlot >> gapRatio: aNumber [
 { #category : #initialization }
 RSBoxPlot >> initialize [
 	super initialize.
+	notched := false.
 	self
 		gapRatio: 0.1;
 		barOffset: 0
@@ -259,6 +303,18 @@ RSBoxPlot >> modeBased [
 { #category : #hooks }
 RSBoxPlot >> modelFor: aPoint [
 	^ aPoint y
+]
+
+{ #category : #accessing }
+RSBoxPlot >> notch [
+
+	^ notched
+]
+
+{ #category : #accessing }
+RSBoxPlot >> notch: aBool [
+
+	notched := aBool
 ]
 
 { #category : #'math functions' }

--- a/src/Roassal3-Chart/RSBoxPlot.class.st
+++ b/src/Roassal3-Chart/RSBoxPlot.class.st
@@ -110,9 +110,7 @@ RSBoxPlot >> computeBoxAndWhiskerExtent: aCollection [
 		factor := self notchFactorFor: confidencePercentage.
 		confidenceIntervalMax := iSort median + (factor * iqr/(iSort size sqrt)).
 		confidenceIntervalMin  := iSort median - (factor * iqr/(iSort size sqrt)).
-		Transcript show: '2 '; show: confidencePercentage ; cr.
-		"Transcript show: '1 '; show: confidenceIntervalMax ; cr.
-		Transcript show: '2 '; show: confidenceIntervalMin; cr."
+
 		bottomWhiskerExtent := quartile1 - (iqr * 1.5).
 		bottomWhiskerExtent <= minVal
 			ifTrue: [ bottomWhiskerExtent := minVal. bottomOutliers := Array new ]
@@ -263,12 +261,6 @@ RSBoxPlot >> confidencePercentage [
 ]
 
 { #category : #accessing }
-RSBoxPlot >> confidencePercentage: aPercentage [
-
-	confidencePercentage := aPercentage
-]
-
-{ #category : #accessing }
 RSBoxPlot >> createdShapes [
 	^ bars
 ]
@@ -306,7 +298,6 @@ RSBoxPlot >> initialize [
 			                (90 -> 1.28).
 			                (95 -> 1.57).
 			                (99 -> 1.81) }.
-	confidencePercentage := 95.
 	self
 		gapRatio: 0.1;
 		barOffset: 0
@@ -381,7 +372,6 @@ RSBoxPlot >> renderIn: canvas [
 	| index |
 	super renderIn: canvas.
 	self checkAssertion.
-	self computeBoxAndWhiskerExtent: yValues.
 	index := 1.
 	bars := xValues flatCollect: [ :xt |
 		| bar |
@@ -389,4 +379,27 @@ RSBoxPlot >> renderIn: canvas [
 		index := index + 1.
 		bar ] as: RSGroup.
 	canvas addAll: bars
+]
+
+{ #category : #public }
+RSBoxPlot >> x: aCollection y: aCollection2 [
+
+	self x: aCollection y: aCollection2 confidence: 95
+]
+
+{ #category : #public }
+RSBoxPlot >> x: aCollection y: aCollection2 confidence: aPercentage [
+
+	xValues := aCollection.
+	yValues := aCollection2.
+	confidencePercentage := aPercentage.
+	self computeBoxAndWhiskerExtent: aCollection2
+]
+
+{ #category : #public }
+RSBoxPlot >> y: aCollection2 confidence: aPercentage [
+
+	self y: aCollection2.
+	confidencePercentage := aPercentage.
+	self computeBoxAndWhiskerExtent: aCollection2
 ]


### PR DESCRIPTION
Improved `RSBoxplot` by adding the possibility to notch the boxplot, that is to say to represent the confidence interval around the median by narrowing the box. The default percentage for the confidence interval is 95%, but it can be changed to 90% or 99%.
Also added tests for it.

Here is an example:
```Smalltalk
| y p1 p2 c size |

y :=  { 
{  1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. 1. 2. 3. 4. 5. 6. 7. }.
{ 1. 2. 3. 4. 5. 6. 7.  } }.

size := 50.

c := RSCompositeChart new.
p1 := RSBoxPlot new.
p1 y: y.
p1 notch: true.
p1 barSize: size.
p1 barOffset: size * -0.55.
p2 := RSBoxPlot new y: y.
p2 barSize: size.
p2 barOffset: size * 0.55.
c add: p1; add: p2.
c open
```
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/23422e90-e573-41e4-b874-358f68b247ac)
