### PR TITLE
HorizontalTopTick and VerticalRightTick

### DIFF
--- a/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
@@ -230,44 +230,44 @@ RSBarChartExample >> example06BarAnimation [
 RSBarChartExample >> example07DoubleBar [
 
 	<script: 'self new example07DoubleBar open'>
-	| c classes x1 x2 y plot title |
-	c := RSCompositeChart new.
+	| classes x1 x2 y plot title |
 	classes := RSShape withAllSubclasses asOrderedCollection sorted: [
 		           :a
 		           :b | a name < b name ].
 	x1 := classes collect: #numberOfMethods.
 	x2 := classes collect: #numberOfVariables.
 	y := 1 to: classes size.
-	c add: (plot := RSDoubleBarPlot new
-			         x1: x1 x2: x2 y: y;
-			         yourself).
+	plot := RSDoubleBarPlot new x1: x1 x2: x2 y: y.
 
-	c horizontalTick numberOfTicks: 10.
-	c addDecoration: (RSHorizontalTopTick new
+	plot horizontalTick
+		numberOfTicks: 10;
+		labelConversion: #asInteger.
+	plot addDecoration: (RSHorizontalTopTick new
 			 values: x2;
-			 numberOfTicks: 10).
+			 numberOfTicks: 10;
+			 labelConversion: #asInteger).
 
-	c xlabel: 'Number Of Methods'.
-	c xlabelTop: 'Number Of Variables'.
+	plot xlabel: 'Number Of Methods'.
+	plot xlabelTop: 'Number Of Variables'.
 
-	c verticalTick fromNames: (classes collect: #name).
-	c addDecoration: (RSVerticalRightTick new
+	plot verticalTick fromNames: (classes collect: #name).
+	plot addDecoration: (RSVerticalRightTick new
 			 values: (1 to: classes size);
 			 numberOfTicks: 10;
 			 fromNames: (classes collect: #linesOfCode)).
 
-	c ylabel: 'Classes'.
-	c ylabelRight: 'Number of lines Of code'.
-	title := c title: 'RSShape withAllSubclasses'.
+	plot ylabel: 'Classes'.
+	plot ylabelRight: 'Number of lines Of code'.
+	title := plot title: 'RSShape withAllSubclasses'.
 	title shape
 		bold;
 		noPaint;
 		withBorder.
 
-	c build.
+	plot build.
 	plot bars , plot bars2 @ RSPopup.
 	title label
 		addInteraction: (RSPopup text: 'Click to inspect');
 		when: RSMouseClick do: [ :evt | classes inspect ] for: self.
-	^ c canvas
+	^ plot canvas
 ]

--- a/src/Roassal3-Chart/RSHorizontalTopTick.class.st
+++ b/src/Roassal3-Chart/RSHorizontalTopTick.class.st
@@ -12,6 +12,13 @@ Class {
 }
 
 { #category : #rendering }
+RSHorizontalTopTick >> beforeRenderingIn: aChart [
+
+	self createXScale.
+	self createYScale
+]
+
+{ #category : #rendering }
 RSHorizontalTopTick >> createTickLineFor: aNumber [
 	| value y |
 	value := xScale scale: aNumber.
@@ -24,22 +31,29 @@ RSHorizontalTopTick >> createTickLineFor: aNumber [
 
 { #category : #rendering }
 RSHorizontalTopTick >> createXScale [
+
 	| padding |
 	xScale ifNil: [ xScale := NSScale linear ].
 	xScale class = NSOrdinalScale ifTrue: [ ^ self ].
 	padding := chart padding x.
 	xScale
-		domain:
-			{self min.
-			self max};
-		range:
-			{0 + padding.
-			chart extent x - padding}
+		domain: {
+				self min.
+				self max };
+		range: {
+				(0 + padding).
+				(chart extent x - padding) }
 ]
 
 { #category : #'accessing - defaults' }
 RSHorizontalTopTick >> defaultLabelLocation [
 	^ RSLocation new above offset: 0@ -3
+]
+
+{ #category : #testing }
+RSHorizontalTopTick >> isHorizontalTick [
+
+	^ true
 ]
 
 { #category : #accessing }
@@ -55,9 +69,7 @@ RSHorizontalTopTick >> min [
 { #category : #rendering }
 RSHorizontalTopTick >> updateChartMaxAndMinValues: aChart [
 
-	aChart
-		minChartValueX: self ticksData first;
-		maxChartValueX: self ticksData last
+	
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSVerticalRightTick.class.st
+++ b/src/Roassal3-Chart/RSVerticalRightTick.class.st
@@ -11,6 +11,13 @@ Class {
 }
 
 { #category : #rendering }
+RSVerticalRightTick >> beforeRenderingIn: aChart [
+
+	self createXScale.
+	self createYScale
+]
+
+{ #category : #rendering }
 RSVerticalRightTick >> createTickLineFor: aNumber [
 	| scaledNumber x |
 	scaledNumber := yScale scale: aNumber.
@@ -21,9 +28,31 @@ RSVerticalRightTick >> createTickLineFor: aNumber [
 		yourself
 ]
 
+{ #category : #rendering }
+RSVerticalRightTick >> createYScale [
+
+	| padding |
+	yScale ifNil: [ yScale := NSScale linear ].
+	yScale class = NSOrdinalScale ifTrue: [ ^ self ].
+	padding := chart padding y.
+	yScale
+		domain: {
+				self min.
+				self max };
+		range: {
+				(0 - padding).
+				(chart extent y negated + padding) }
+]
+
 { #category : #'accessing - defaults' }
 RSVerticalRightTick >> defaultLabelLocation [
 	^ RSLocation new outer; right; offset: 2@0
+]
+
+{ #category : #testing }
+RSVerticalRightTick >> isVerticalTick [
+
+	^ true
 ]
 
 { #category : #accessing }
@@ -39,9 +68,7 @@ RSVerticalRightTick >> min [
 { #category : #rendering }
 RSVerticalRightTick >> updateChartMaxAndMinValues: aChart [
 
-	aChart
-		minChartValueY: self ticksData first;
-		maxChartValueY: self ticksData last
+	
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fixed horizontal top and vertical right ticks. The goal was to fix `RSDoubleBarPlot`, especially the example `example07DoubleBar`.

From this:
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/3d78acea-1abe-45f4-84c8-3873a4249371)

To this:
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/700de19b-226b-480f-8cfa-a73b0a532cfc)
