### PR TITLE
Fixed DoubleBarPlot

### DIFF
--- a/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
+++ b/src/Roassal3-Chart-Examples/RSBarChartExample.class.st
@@ -242,10 +242,9 @@ RSBarChartExample >> example07DoubleBar [
 	plot horizontalTick
 		numberOfTicks: 10;
 		labelConversion: #asInteger.
-	plot addDecoration: (RSHorizontalTopTick new
-			 values: x2;
-			 numberOfTicks: 10;
-			 labelConversion: #asInteger).
+	plot horizontalTopTick
+		numberOfTicks: 10;
+		labelConversion: #asInteger.
 
 	plot xlabel: 'Number Of Methods'.
 	plot xlabelTop: 'Number Of Variables'.

--- a/src/Roassal3-Chart/RSDoubleBarPlot.class.st
+++ b/src/Roassal3-Chart/RSDoubleBarPlot.class.st
@@ -55,8 +55,8 @@ RSDoubleBarPlot >> createXScale [
 	padding := self padding x.
 	x2Scale
 		domain:
-			{x2Values min.
-			x2Values max};
+			{x2Values min min: 0.
+			x2Values max max: 0};
 		range:
 			{0 + padding.
 			self extent x - padding}
@@ -69,15 +69,19 @@ RSDoubleBarPlot >> createdShapes [
 
 { #category : #rendering }
 RSDoubleBarPlot >> renderIn: canvas [
+
 	| index |
+	self addDecoration: (RSHorizontalTopTick new values: x2Values).
 	super renderIn: canvas.
 	index := 1.
-	bars2 := x2Values collect: [ :xt |
-		| yt bar |
-		yt := yValues at: index.
-		bar := self createBar2For: xt@yt index: index.
-		index := index + 1.
-		bar ] as: RSGroup.
+	bars2 := x2Values
+		         collect: [ :xt |
+			         | yt bar |
+			         yt := yValues at: index.
+			         bar := self createBar2For: xt @ yt index: index.
+			         index := index + 1.
+			         bar ]
+		         as: RSGroup.
 	canvas addAll: bars2
 ]
 
@@ -91,6 +95,12 @@ RSDoubleBarPlot >> x1: x1 x2: x2 y: y [
 	self assert: x1 size = y size description: 'The two collections must have the same size'.
 	self x: x1 y: y.
 	x2Values := x2
+]
+
+{ #category : #accessing }
+RSDoubleBarPlot >> x2Scale [
+
+	^ x2Scale
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSDoubleBarPlot.class.st
+++ b/src/Roassal3-Chart/RSDoubleBarPlot.class.st
@@ -8,7 +8,8 @@ Class {
 		'x2Values',
 		'secondColor',
 		'x2Scale',
-		'bars2'
+		'bars2',
+		'horizontalTopTick'
 	],
 	#category : #'Roassal3-Chart-Core'
 }
@@ -67,11 +68,24 @@ RSDoubleBarPlot >> createdShapes [
 	^ bars, bars2
 ]
 
+{ #category : #accessing }
+RSDoubleBarPlot >> horizontalTopTick [
+
+	^ horizontalTopTick
+]
+
+{ #category : #initialization }
+RSDoubleBarPlot >> initializeDecorations [
+	
+	super initializeDecorations.
+	horizontalTopTick := RSHorizontalTopTick new.
+	self addDecoration: horizontalTopTick
+]
+
 { #category : #rendering }
 RSDoubleBarPlot >> renderIn: canvas [
 
 	| index |
-	self addDecoration: (RSHorizontalTopTick new values: x2Values).
 	super renderIn: canvas.
 	index := 1.
 	bars2 := x2Values
@@ -92,9 +106,10 @@ RSDoubleBarPlot >> secondColor [
 
 { #category : #accessing }
 RSDoubleBarPlot >> x1: x1 x2: x2 y: y [
-	self assert: x1 size = y size description: 'The two collections must have the same size'.
+	self assert: x1 size = x2 size description: 'The two collections must have the same size'.
 	self x: x1 y: y.
-	x2Values := x2
+	x2Values := x2.
+	horizontalTopTick values: x2Values
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSHorizontalTopTick.class.st
+++ b/src/Roassal3-Chart/RSHorizontalTopTick.class.st
@@ -58,12 +58,12 @@ RSHorizontalTopTick >> isHorizontalTick [
 
 { #category : #accessing }
 RSHorizontalTopTick >> max [
-	^ values max
+	^ values max max: 0
 ]
 
 { #category : #accessing }
 RSHorizontalTopTick >> min [
-	^ values min
+	^ values min min: 0
 ]
 
 { #category : #rendering }


### PR DESCRIPTION
Fixed actual `RSDoubleBarPlot` class, the scale of the second bar made it go out of the spine in some cases.
Also added horizontalTopTick by default, some accessers, and another fix to `RSHorizontalTopTick` to always display 0.