### PR TITLE
Do not use `RPackage organizer`

### DIFF
--- a/src/Roassal3-Global-Tests/RSRoassal3Test.class.st
+++ b/src/Roassal3-Global-Tests/RSRoassal3Test.class.st
@@ -8,7 +8,7 @@ Class {
 RSRoassal3Test >> testInitializeInRoassal [
 
 	| pkgs methods violating |
-	pkgs := RPackage organizer packages select: [ :pkg | 'Roassal3*' match: pkg name ].
+	pkgs := self class packageOrganizer packages select: [ :pkg | 'Roassal3*' match: pkg name ].
 	methods := pkgs flatCollect: [ :pkg | pkg definedClasses flatCollect: [ :class | class methods ] ].
 	violating := methods select: [ :method | method selector = #initialize and: [ method protocolName ~= #initialization ] ].
 	self assert: violating isEmpty description: 'Roassal initialize methods should be categorized in initialization'


### PR DESCRIPTION
This method emulates a dynamic global variable and is plan for deprecation. This PR provides an alternative way to access the organizer that does not contains the hacks of `RPackage organizer`.