### PR TITLE
Add RSViolinPlot compatibility with a model and DataFrame

### DIFF
--- a/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
+++ b/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
@@ -55,6 +55,7 @@ RSViolinPlot class >> example04DataFrame [
 	| boxPlot1 toothGrowth |
 	toothGrowth := AIDatasets loadToothGrowth.
 	boxPlot1 := self dataFrame: toothGrowth x: #dose y: #len.
-	boxPlot1 bandwidth: 2.
+	boxPlot1 color: Color purple translucent.
+	"boxPlot1 bandwidth: 2."
 	^ boxPlot1 open
 ]

--- a/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
+++ b/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
@@ -13,17 +13,20 @@ RSViolinPlot class >> dataFrame: aDataSeriesOrDataFrame [
 { #category : #'*Roassal3-Chart-DataFrame' }
 RSViolinPlot class >> dataFrame: aDataFrame x: aColumnNameToCategory y: aColumnNameOfData [
 
-	| categoryNames data violinPlot |
+	| categoryNames data violinPlot collectionOfDataSeries |
 	data := OrderedCollection new.
 	categoryNames := (aDataFrame column: aColumnNameToCategory)
 		                 uniqueValues sort.
+	collectionOfDataSeries := OrderedCollection new. 
 	categoryNames do: [ :categoryName |
 		| aDataSeries |
 		aDataSeries := (aDataFrame select: [ :row |
 			                (row at: aColumnNameToCategory) = categoryName ])
 			               column: aColumnNameOfData.
-		data add: aDataSeries asArray ].
+		collectionOfDataSeries add: aDataSeries.
+		data add: [:ds|ds asArray].] .
 	violinPlot := self new.
+	violinPlot models: collectionOfDataSeries.
 	violinPlot data: data.
 	violinPlot xTickLabels: categoryNames.
 	violinPlot ylabel: aColumnNameOfData.

--- a/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
+++ b/src/Roassal3-Chart-DataFrame/RSViolinPlot.extension.st
@@ -1,0 +1,57 @@
+Extension { #name : #RSViolinPlot }
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlot class >> dataFrame: aDataSeriesOrDataFrame [
+	| violinPlot aDataSeries |
+	violinPlot := self new.
+	aDataSeriesOrDataFrame class = DataSeries 
+		ifTrue: [ aDataSeries := aDataSeriesOrDataFrame ].
+	violinPlot dataSeries: aDataSeries.
+	^ violinPlot
+]
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlot class >> dataFrame: aDataFrame x: aColumnNameToCategory y: aColumnNameOfData [
+
+	| categoryNames data violinPlot |
+	data := OrderedCollection new.
+	categoryNames := (aDataFrame column: aColumnNameToCategory)
+		                 uniqueValues sort.
+	categoryNames do: [ :categoryName |
+		| aDataSeries |
+		aDataSeries := (aDataFrame select: [ :row |
+			                (row at: aColumnNameToCategory) = categoryName ])
+			               column: aColumnNameOfData.
+		data add: aDataSeries asArray ].
+	violinPlot := self new.
+	violinPlot data: data.
+	violinPlot xTickLabels: categoryNames.
+	violinPlot ylabel: aColumnNameOfData.
+	violinPlot xlabel: aColumnNameToCategory.
+	^ violinPlot
+]
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlot >> dataSeries: aDataSeries [
+	self data: aDataSeries asArray.
+	self ylabel: aDataSeries name.
+]
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlot class >> example03DataSeries [
+
+	| boxPlot1 toothGrowthDose |
+	toothGrowthDose := (AIDatasets loadToothGrowth) column: 'dose'.
+	boxPlot1 := self dataFrame: toothGrowthDose.
+	^ boxPlot1 open
+]
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlot class >> example04DataFrame [
+
+	| boxPlot1 toothGrowth |
+	toothGrowth := AIDatasets loadToothGrowth.
+	boxPlot1 := self dataFrame: toothGrowth x: #dose y: #len.
+	boxPlot1 bandwidth: 2.
+	^ boxPlot1 open
+]

--- a/src/Roassal3-Chart-DataFrame/RSViolinPlotTest.extension.st
+++ b/src/Roassal3-Chart-DataFrame/RSViolinPlotTest.extension.st
@@ -1,0 +1,27 @@
+Extension { #name : #RSViolinPlotTest }
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlotTest >> testModelDataFrame [
+	| violinPlot aModel window |	
+	aModel := AIDatasets loadToothGrowth.
+	violinPlot := RSViolinPlot model: aModel.
+	violinPlot data: [ :df | (df column: #len) asArray].
+	window := violinPlot open.
+	self assert: violinPlot model equals: aModel.
+	self assert: violinPlot data equals: ((aModel column: #len) asArray).
+	window delete.
+]
+
+{ #category : #'*Roassal3-Chart-DataFrame' }
+RSViolinPlotTest >> testModelOfEachViolinDataSeries [
+	| violinPlot window dataFrame dataSeries1 dataSeries2 |
+	dataFrame := AIDatasets loadToothGrowth.
+	dataSeries1 := (dataFrame select: [ :row | (row at: #dose) = 1 ]) column: #len.
+	dataSeries2 := (dataFrame select: [ :row | (row at: #dose) = 2 ]) column: #len.
+	violinPlot := RSViolinPlot models: {dataSeries1. dataSeries2.}.
+	violinPlot data: {[ :ds1 | ds1 asArray]. [ :ds2 | ds2 asArray].}.
+	window := violinPlot open.
+	self assert: violinPlot models equals: {dataSeries1. dataSeries2. } asOrderedCollection.
+	self assert: violinPlot data equals: {dataSeries1 asArray. dataSeries2 asArray.} asOrderedCollection.
+	window delete.
+]

--- a/src/Roassal3-Chart-DataFrame/package.st
+++ b/src/Roassal3-Chart-DataFrame/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Roassal3-Chart-DataFrame' }

--- a/src/Roassal3-Chart-Tests/RSViolinPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSViolinPlotTest.class.st
@@ -41,6 +41,36 @@ RSViolinPlotTest >> testBasicViolinPlot [
 ]
 
 { #category : #tests }
+RSViolinPlotTest >> testBorders [
+	| violinPlotA data |
+	
+	data := #(10 20 30 40 40 50).
+	violinPlotA := RSViolinPlot data: data.
+	self assert: violinPlotA borders class equals: Array.
+	self assert: violinPlotA borders first class equals: RSBorder.
+]
+
+{ #category : #tests }
+RSViolinPlotTest >> testBordersColor [
+	| violinPlotA data |
+	
+	data := #(10 20 30 40 40 50).
+	violinPlotA := RSViolinPlot data: data.
+	violinPlotA borderColor: Color red.
+	self assert: violinPlotA borderColor equals: Color red.
+]
+
+{ #category : #tests }
+RSViolinPlotTest >> testBordersColors [
+	| violinPlotA data |
+	
+	data := {{6. 8. 7. 5. 7. 11. 9. }. { 12. 12. 13. 15. 18. 20. 21. 24. }}.
+	violinPlotA := RSViolinPlot data: data.
+	violinPlotA bordersColors: {Color red. Color green.}.
+	self assert: violinPlotA bordersColor equals: {Color red. Color green.}.
+]
+
+{ #category : #tests }
 RSViolinPlotTest >> testTwoViolinPlots [
 	| violinPlot data window |
 	data := {{10. 20. 30. 40. 40. 50.}. {1. 30. 30. 30. 30. 40. 40. 50.}.}.

--- a/src/Roassal3-Chart-Tests/RSViolinPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSViolinPlotTest.class.st
@@ -71,6 +71,38 @@ RSViolinPlotTest >> testBordersColors [
 ]
 
 { #category : #tests }
+RSViolinPlotTest >> testModel [
+	| violinPlot aModel window |    
+	aModel := String.
+	violinPlot := RSViolinPlot model: aModel.
+	violinPlot data: [ :cls | cls methods collect: [:met | met linesOfCode ] ].
+	window := violinPlot open.
+	self assert: violinPlot model equals: aModel.
+	window delete.
+
+]
+
+{ #category : #tests }
+RSViolinPlotTest >> testModelOfEachViolin [
+	| violinPlot window aModel1 aModel2 dataset1 dataset2 waysToGetDataFromModels |
+	aModel1 := String.
+	aModel2 := Number.
+	waysToGetDataFromModels := { 
+		[ :cls | cls methods collect: [:met | met linesOfCode ] ].
+		[ :cls | cls methods collect: [:met | met linesOfCode ] ].
+	}.
+	violinPlot := RSViolinPlot models: {aModel1. aModel2.}.
+	violinPlot data: waysToGetDataFromModels.
+	dataset1 := (waysToGetDataFromModels first) rsValue: aModel1. 
+	dataset2 := (waysToGetDataFromModels first) rsValue: aModel2.
+	
+	window := violinPlot open.
+	self assert: violinPlot models equals: {aModel1. aModel2. } asOrderedCollection.
+	self assert: violinPlot data equals: {dataset1. dataset2.} asOrderedCollection.
+	window delete.
+]
+
+{ #category : #tests }
 RSViolinPlotTest >> testTwoViolinPlots [
 	| violinPlot data window |
 	data := {{10. 20. 30. 40. 40. 50.}. {1. 30. 30. 30. 30. 40. 40. 50.}.}.

--- a/src/Roassal3-Chart/RSBoxPlotShape.class.st
+++ b/src/Roassal3-Chart/RSBoxPlotShape.class.st
@@ -177,10 +177,10 @@ RSBoxPlotShape >> computeOutliers [
 	"graphCenter was already computed in shapesWithCenterAt"
 	outliersPoints := statisticalMeasures outliers collect: [ :y | graphCenter@ (yScale scale: y) ].
 	outliers := outliersPoints.
+	outlier extent x isZero ifTrue: [ outlier size: bandWidth * 0.15 ].
 	outliers := outliers collect: [ :out |
 			| e |
 			e := outlier.
-			e size: bandWidth * 0.15.
 			e translateTo: out.
 	] as: RSGroup.
 	^ outliers.
@@ -272,7 +272,8 @@ RSBoxPlotShape >> defaultNotched [
 RSBoxPlotShape >> defaultOutlier [
 	^ RSEllipse new
 		radius: 4;
-		color: Color black.
+		color: Color black;
+		size: 0.
 ]
 
 { #category : #defaults }
@@ -387,6 +388,11 @@ RSBoxPlotShape >> outlier: markerShape [
 { #category : #accessing }
 RSBoxPlotShape >> outlierMarker: markerShapeString [
 	outlier := (RSShapeFactory shapeFromString: markerShapeString) color: Color black.
+]
+
+{ #category : #accessing }
+RSBoxPlotShape >> outlierSize: aDimensionInPixels [
+	outlier size: aDimensionInPixels.
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -61,13 +61,33 @@ RSViolinPlot class >> data: aCollection [
 ]
 
 { #category : #accessing }
-RSViolinPlot class >> exampleViolinPlot [
+RSViolinPlot class >> example01BasicViolinPlot [
 	| boxPlot1   data1  |
 	data1 := { 12. 12. 13. 14. 15. 24. }.
 	boxPlot1 := self data: data1.
 	boxPlot1 xlabel: 'x axis'.
 	boxPlot1 ylabel: 'y axis'.
 	^ boxPlot1 open.
+]
+
+{ #category : #accessing }
+RSViolinPlot class >> example02MultipleVionlinsArrayOfArrays [
+
+	| boxPlot1 |
+	boxPlot1 := self data: {
+			            {6. 8. 7. 5. 7. 11. 9. }.
+			            {2. 2. 2. 3. 3. 12. 4. 2. 4. 2. 2. 2. 6. 2. 2. 8. 2. 5. 9. 2. 2. 2. 2. 2.}. }.
+	^ boxPlot1 open
+]
+
+{ #category : #accessing }
+RSViolinPlot class >> exampleStyleColor [
+	| violinPlot data |
+	data := {{-5. 12. 12. 13. 14. 14. 15. 24. }.}.
+	violinPlot := self data: data.
+	violinPlot bandwidth: 3.
+	violinPlot color: Color purple translucent.
+	^ violinPlot open.
 ]
 
 { #category : #accessing }
@@ -86,16 +106,6 @@ RSViolinPlot class >> exampleViolinPlotClusters [
 	aRSClusterChart := violinPlotA + violinPlotB.
 	
 	^ aRSClusterChart open.
-]
-
-{ #category : #accessing }
-RSViolinPlot class >> exampleViolinPlotColor [
-	| violinPlot data |
-	data := {{-5. 12. 12. 13. 14. 14. 15. 24. }. {-5. 12. 12. 13. 14. 14. 15. 24. }.}.
-	violinPlot := self data: data.
-	violinPlot bandwidth: 3.
-	violinPlot color: Color green.
-	^ violinPlot open.
 ]
 
 { #category : #accessing }

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -112,11 +112,12 @@ RSViolinPlot class >> exampleStyleBorderOfEachViolin [
 
 	| violinPlot2 data2 |
 	
-	data2 := {{ 12. 12. 13. 15. 18. 20. 21. 24. }.{15. 15. 18. 12. 13. 10. 11. 14.}.}.
+	data2 := {{ 12. 12. 13. 15. 18. 20. 21. 24. }.{15. 15. 18. 12. 13. 10. 11. 14.}. {14. 14. 16. 12. 13. 10. 11. 14.}.}.
 	
 	violinPlot2 := self data: data2.
 	violinPlot2 borders first color: Color red; dashArray: { 4. }. "way 1"
-	violinPlot2 violinShapes last borderColor: Color orange. "way 2"
+	violinPlot2 violinShapes second borderColor: Color orange. "way 2"
+	violinPlot2 violinShapes third border color: Color green. "way 3"
 	
 	^ violinPlot2 open
 ]

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -60,6 +60,35 @@ RSViolinPlot class >> data: aCollection [
 	^ boxPlot
 ]
 
+{ #category : #accessing }
+RSViolinPlot class >> dataFrame: aDataSeriesOrDataFrame [
+	| violinPlot aDataSeries |
+	violinPlot := self new.
+	aDataSeriesOrDataFrame class = DataSeries 
+		ifTrue: [ aDataSeries := aDataSeriesOrDataFrame ].
+	violinPlot dataSeries: aDataSeries.
+	^ violinPlot
+]
+
+{ #category : #accessing }
+RSViolinPlot class >> dataFrame: aDataFrame x: aColumnNameToCategory y: aColumnNameOfData [
+
+	| categoryNames data violinPlot |
+	data := OrderedCollection new.
+	categoryNames := (aDataFrame column: aColumnNameToCategory)
+		                 uniqueValues sort.
+	categoryNames do: [ :categoryName |
+		| aDataSeries |
+		aDataSeries := (aDataFrame select: [ :row |
+			                (row at: aColumnNameToCategory) = categoryName ])
+			               column: aColumnNameOfData.
+		data add: aDataSeries asArray ].
+	violinPlot := self new.
+	violinPlot data: data.
+	violinPlot xTickLabels: categoryNames.
+	^ violinPlot
+]
+
 { #category : #examples }
 RSViolinPlot class >> example01BasicViolinPlot [
 	| boxPlot1   data1  |
@@ -77,6 +106,25 @@ RSViolinPlot class >> example02MultipleVionlinsArrayOfArrays [
 	boxPlot1 := self data: {
 			            {6. 8. 7. 5. 7. 11. 9. }.
 			            {2. 2. 2. 3. 3. 12. 4. 2. 4. 2. 2. 2. 6. 2. 2. 8. 2. 5. 9. 2. 2. 2. 2. 2.}. }.
+	^ boxPlot1 open
+]
+
+{ #category : #examples }
+RSViolinPlot class >> example03DataSeries [
+
+	| boxPlot1 toothGrowthDose |
+	toothGrowthDose := (AIDatasets loadToothGrowth) column: 'dose'.
+	boxPlot1 := self dataFrame: toothGrowthDose.
+	^ boxPlot1 open
+]
+
+{ #category : #examples }
+RSViolinPlot class >> example04DataFrame [
+
+	| boxPlot1 toothGrowth |
+	toothGrowth := AIDatasets loadToothGrowth.
+	boxPlot1 := self dataFrame: toothGrowth x: #dose y: #len.
+	"boxPlot1 bandwidth: 2."
 	^ boxPlot1 open
 ]
 

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -60,35 +60,6 @@ RSViolinPlot class >> data: aCollection [
 	^ boxPlot
 ]
 
-{ #category : #accessing }
-RSViolinPlot class >> dataFrame: aDataSeriesOrDataFrame [
-	| violinPlot aDataSeries |
-	violinPlot := self new.
-	aDataSeriesOrDataFrame class = DataSeries 
-		ifTrue: [ aDataSeries := aDataSeriesOrDataFrame ].
-	violinPlot dataSeries: aDataSeries.
-	^ violinPlot
-]
-
-{ #category : #accessing }
-RSViolinPlot class >> dataFrame: aDataFrame x: aColumnNameToCategory y: aColumnNameOfData [
-
-	| categoryNames data violinPlot |
-	data := OrderedCollection new.
-	categoryNames := (aDataFrame column: aColumnNameToCategory)
-		                 uniqueValues sort.
-	categoryNames do: [ :categoryName |
-		| aDataSeries |
-		aDataSeries := (aDataFrame select: [ :row |
-			                (row at: aColumnNameToCategory) = categoryName ])
-			               column: aColumnNameOfData.
-		data add: aDataSeries asArray ].
-	violinPlot := self new.
-	violinPlot data: data.
-	violinPlot xTickLabels: categoryNames.
-	^ violinPlot
-]
-
 { #category : #examples }
 RSViolinPlot class >> example01BasicViolinPlot [
 	| boxPlot1   data1  |
@@ -106,25 +77,6 @@ RSViolinPlot class >> example02MultipleVionlinsArrayOfArrays [
 	boxPlot1 := self data: {
 			            {6. 8. 7. 5. 7. 11. 9. }.
 			            {2. 2. 2. 3. 3. 12. 4. 2. 4. 2. 2. 2. 6. 2. 2. 8. 2. 5. 9. 2. 2. 2. 2. 2.}. }.
-	^ boxPlot1 open
-]
-
-{ #category : #examples }
-RSViolinPlot class >> example03DataSeries [
-
-	| boxPlot1 toothGrowthDose |
-	toothGrowthDose := (AIDatasets loadToothGrowth) column: 'dose'.
-	boxPlot1 := self dataFrame: toothGrowthDose.
-	^ boxPlot1 open
-]
-
-{ #category : #examples }
-RSViolinPlot class >> example04DataFrame [
-
-	| boxPlot1 toothGrowth |
-	toothGrowth := AIDatasets loadToothGrowth.
-	boxPlot1 := self dataFrame: toothGrowth x: #dose y: #len.
-	"boxPlot1 bandwidth: 2."
 	^ boxPlot1 open
 ]
 

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -233,6 +233,11 @@ RSViolinPlot >> borderColor: aColor [
 	self bordersColor: aColor.
 ]
 
+{ #category : #styling }
+RSViolinPlot >> borderColors: aCollectionOfColors [
+	self bordersColors: aCollectionOfColors.
+]
+
 { #category : #accessing }
 RSViolinPlot >> borders [
 	^ violinShapes collect: [ :violin | violin border ].

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -47,7 +47,8 @@ Class {
 	#instVars : [
 		'violinShapes',
 		'offset',
-		'bandWidth'
+		'bandWidth',
+		'model'
 	],
 	#category : #'Roassal3-Chart-Core'
 }
@@ -198,6 +199,22 @@ RSViolinPlot class >> exampleViolinPlotWithOutliers [
 	^ violinPlot open.
 ]
 
+{ #category : #accessing }
+RSViolinPlot class >> model: aModel [
+	| boxPlot |
+	boxPlot := self new.
+	boxPlot model: aModel.
+	^ boxPlot
+]
+
+{ #category : #accessing }
+RSViolinPlot class >> models: aCollectionOfModels [
+	| boxPlot |
+	boxPlot := self new.
+	boxPlot models: aCollectionOfModels.
+	^ boxPlot
+]
+
 { #category : #rendering }
 RSViolinPlot >> bandsOffset: aNumberInRange [
 	offset := aNumberInRange
@@ -328,16 +345,40 @@ RSViolinPlot >> createdShapes [
 ]
 
 { #category : #rendering }
-RSViolinPlot >> data: aCollection [
+RSViolinPlot >> data [
 	| collectionOfDatasets |
+	collectionOfDatasets := violinShapes collect: [ :violin | violin data ].
+	collectionOfDatasets size = 1 ifTrue: [ collectionOfDatasets := collectionOfDatasets first].
+	^ collectionOfDatasets.
+]
+
+{ #category : #rendering }
+RSViolinPlot >> data: dataset [
 	
-	"if is not a collection of collections. transform in a collection of collections"
-	collectionOfDatasets := aCollection first isCollection
-		                        ifFalse: [ { aCollection } ]
-		                        ifTrue: [ aCollection ].
-	self violinShapes: (collectionOfDatasets collect: [ :dataSet | RSViolinPlotShape data: dataSet]).
-	"self computeBoxGraphicsCenters."
-	self computeState.
+	"dataset could be:
+	- aCollection of raw data (numbers)
+	- aCollection of collections
+	- aBlock to get the data from the model (previously stored in model)
+	- aCollection of Blocks to get several violins, 
+	  each block define how to get the data from the model of each violinShape
+	  (previously stored on models"
+	
+	| collectionOfDatasets aCollection |
+	aCollection := dataset rsValue: model.
+	collectionOfDatasets := ((aCollection first isCollection) or: (aCollection first isBlock))
+		                        ifTrue: [ aCollection ]
+										ifFalse: [ { aCollection } ].
+	violinShapes isEmpty 
+		ifTrue: [ 
+			self violinShapes: (collectionOfDatasets collect: [ :dataSet |
+				 RSViolinPlotShape data: dataSet ]).
+		]
+		ifFalse: [ 
+			collectionOfDatasets doWithIndex: [ :dataSet :idx |
+				(violinShapes at: idx) data: dataSet ].
+		 ].
+
+	self computeState
 ]
 
 { #category : #rendering }
@@ -351,10 +392,41 @@ RSViolinPlot >> defaultShape [
 		noPaint.
 ]
 
+{ #category : #initialization }
+RSViolinPlot >> initialize [
+	super initialize.
+	violinShapes := OrderedCollection new.
+]
+
 { #category : #rendering }
 RSViolinPlot >> kernelBandwidth: aNumber [
 	violinShapes do: [ :violin | violin kernelBandwidth: aNumber ].
 	self computeState.
+]
+
+{ #category : #rendering }
+RSViolinPlot >> model [
+	^ model
+]
+
+{ #category : #rendering }
+RSViolinPlot >> model: aModel [
+	model := aModel
+]
+
+{ #category : #rendering }
+RSViolinPlot >> models [
+	^ violinShapes collect: [ :violin | violin model ]
+]
+
+{ #category : #rendering }
+RSViolinPlot >> models: aCollectionOfModels [
+	aCollectionOfModels do: [ :violinShapeModel |
+		| violinShape |
+		violinShape := RSViolinPlotShape new.
+		violinShape model: violinShapeModel.
+		violinShapes add: violinShape. 
+	]. 
 ]
 
 { #category : #rendering }

--- a/src/Roassal3-Chart/RSViolinPlot.class.st
+++ b/src/Roassal3-Chart/RSViolinPlot.class.st
@@ -60,7 +60,7 @@ RSViolinPlot class >> data: aCollection [
 	^ boxPlot
 ]
 
-{ #category : #accessing }
+{ #category : #examples }
 RSViolinPlot class >> example01BasicViolinPlot [
 	| boxPlot1   data1  |
 	data1 := { 12. 12. 13. 14. 15. 24. }.
@@ -70,7 +70,7 @@ RSViolinPlot class >> example01BasicViolinPlot [
 	^ boxPlot1 open.
 ]
 
-{ #category : #accessing }
+{ #category : #examples }
 RSViolinPlot class >> example02MultipleVionlinsArrayOfArrays [
 
 	| boxPlot1 |
@@ -80,7 +80,74 @@ RSViolinPlot class >> example02MultipleVionlinsArrayOfArrays [
 	^ boxPlot1 open
 ]
 
-{ #category : #accessing }
+{ #category : #'examples - styling' }
+RSViolinPlot class >> exampleStyleBorder [
+
+	| violinPlot2 data2 |
+	
+	data2 := {{ 12. 12. 13. 15. 18. 20. 21. 24. }.{15. 15. 18. 12. 13. 10. 11. 14.}.}.
+	
+	violinPlot2 := self data: data2.
+	violinPlot2 borders do: [ :aRSBorder | aRSBorder color: Color red; dashArray: { 4. }. ].
+	
+	^ violinPlot2 open
+]
+
+{ #category : #'examples - styling' }
+RSViolinPlot class >> exampleStyleBorderColorOfEachViolin [
+
+	| violinPlot1 data1 |
+	
+	data1 := {{6. 8. 7. 5. 7. 11. 9. }. { 12. 12. 13. 15. 18. 20. 21. 24. }}.
+	
+	violinPlot1 := self data: data1.
+	violinPlot1 borders first color: Color green.
+	violinPlot1 violinShapes last borderColor: Color red.
+	
+	^ violinPlot1 open
+]
+
+{ #category : #'examples - styling' }
+RSViolinPlot class >> exampleStyleBorderOfEachViolin [
+
+	| violinPlot2 data2 |
+	
+	data2 := {{ 12. 12. 13. 15. 18. 20. 21. 24. }.{15. 15. 18. 12. 13. 10. 11. 14.}.}.
+	
+	violinPlot2 := self data: data2.
+	violinPlot2 borders first color: Color red; dashArray: { 4. }. "way 1"
+	violinPlot2 violinShapes last borderColor: Color orange. "way 2"
+	
+	^ violinPlot2 open
+]
+
+{ #category : #'examples - styling' }
+RSViolinPlot class >> exampleStyleBordersColor [
+
+	| violinPlot1 data1 |
+	
+	data1 := {{6. 8. 7. 5. 7. 11. 9. }. { 12. 12. 13. 15. 18. 20. 21. 24. }}.
+	
+	violinPlot1 := self data: data1.
+	violinPlot1 bordersColor: Color red.
+	
+	^ violinPlot1 open
+]
+
+{ #category : #'examples - styling' }
+RSViolinPlot class >> exampleStyleBordersColors [
+
+	| violinPlot1 data1 |
+	
+	data1 := {{6. 8. 7. 5. 7. 11. 9. }. { 12. 12. 13. 15. 18. 20. 21. 24. }}.
+	
+	violinPlot1 := self data: data1.
+	violinPlot1 bordersColors: {Color red. Color purple.}.
+	
+	^ violinPlot1 open
+]
+
+{ #category : #'examples - styling' }
 RSViolinPlot class >> exampleStyleColor [
 	| violinPlot data |
 	data := {{-5. 12. 12. 13. 14. 14. 15. 24. }.}.
@@ -90,7 +157,7 @@ RSViolinPlot class >> exampleStyleColor [
 	^ violinPlot open.
 ]
 
-{ #category : #accessing }
+{ #category : #examples }
 RSViolinPlot class >> exampleViolinPlotClusters [
 	| violinPlotA violinPlotB data aRSClusterChart |
 	data := {{-5. 12. 12. 13. 14. 14. 15. 24. }. {-5. 12. 12. 13. 14. 14. 15. 24. }.}.
@@ -108,7 +175,7 @@ RSViolinPlot class >> exampleViolinPlotClusters [
 	^ aRSClusterChart open.
 ]
 
-{ #category : #accessing }
+{ #category : #examples }
 RSViolinPlot class >> exampleViolinPlotColors [
 	| violinPlot data |
 	data := {{-5. 12. 12. 13. 14. 14. 15. 24. }. {-5. 12. 12. 13. 14. 14. 15. 24. }.}.
@@ -121,7 +188,7 @@ RSViolinPlot class >> exampleViolinPlotColors [
 	^ violinPlot open.
 ]
 
-{ #category : #accessing }
+{ #category : #examples }
 RSViolinPlot class >> exampleViolinPlotWithOutliers [
 	| violinPlot data |
 	data := {-5. 12. 12. 13. 14. 14. 15. 24. }.
@@ -154,6 +221,38 @@ RSViolinPlot >> beforeRenderingIn: aChart [
 		domain: xValues;
 		rangeBands: { 0. aChart extent x. }.
 	aChart xScale: bandScale.
+]
+
+{ #category : #accessing }
+RSViolinPlot >> borderColor [
+	^ self bordersColor first.
+]
+
+{ #category : #styling }
+RSViolinPlot >> borderColor: aColor [
+	self bordersColor: aColor.
+]
+
+{ #category : #accessing }
+RSViolinPlot >> borders [
+	^ violinShapes collect: [ :violin | violin border ].
+]
+
+{ #category : #accessing }
+RSViolinPlot >> bordersColor [
+	^ self borders collect: [ :border | border color ]
+]
+
+{ #category : #styling }
+RSViolinPlot >> bordersColor: aColor [
+	self borders do: [ :border | border color: aColor].
+]
+
+{ #category : #styling }
+RSViolinPlot >> bordersColors: aCollectionOfColors [
+	| borders |
+	borders := self borders.
+	aCollectionOfColors doWithIndex: [ :aColor :idx | (borders at: idx) color: aColor].
 ]
 
 { #category : #rendering }

--- a/src/Roassal3-Chart/RSViolinPlotShape.class.st
+++ b/src/Roassal3-Chart/RSViolinPlotShape.class.st
@@ -34,6 +34,16 @@ RSViolinPlotShape >> bandWidth: aNumber [
 	boxPlotShape bandWidth: bandWidth*0.1.
 ]
 
+{ #category : #accessing }
+RSViolinPlotShape >> border [
+	^ densityArea border.
+]
+
+{ #category : #styling }
+RSViolinPlotShape >> borderColor: aColor [
+	^ self border color: aColor.
+]
+
 { #category : #initialization }
 RSViolinPlotShape >> color [
 	^ color
@@ -68,7 +78,8 @@ RSViolinPlotShape >> defaultBoxPlotShape [
 { #category : #defaults }
 RSViolinPlotShape >> defaultDensityArea [
 	^ RSPolygon new
-		noPaint.
+		noPaint
+		borderColor: Color black.
 ]
 
 { #category : #defaults }
@@ -107,8 +118,6 @@ RSViolinPlotShape >> densityArea [
 	
 	
 	densityArea points: densityAreaPoints.
-
-	densityArea borderColor: Color black.
 	densityArea color: color.
 	^ densityArea
 ]

--- a/src/Roassal3-Chart/RSViolinPlotShape.class.st
+++ b/src/Roassal3-Chart/RSViolinPlotShape.class.st
@@ -9,7 +9,8 @@ Class {
 		'xScale',
 		'yScale',
 		'bandOffset',
-		'bandWidth'
+		'bandWidth',
+		'model'
 	],
 	#category : #'Roassal3-Chart-Plots'
 }
@@ -61,8 +62,10 @@ RSViolinPlotShape >> data [
 
 { #category : #accessing }
 RSViolinPlotShape >> data: dataset [
-	kernelDensity data: dataset.
-	boxPlotShape data: dataset.
+	| aCollection |
+	aCollection := dataset rsValue: model.
+	kernelDensity data: aCollection.
+	boxPlotShape data: aCollection.
 ]
 
 { #category : #accessing }
@@ -147,6 +150,16 @@ RSViolinPlotShape >> minYValue [
 	| minYValueOfCurve |
 	minYValueOfCurve := (kernelDensity densityCurve collect: [ :point | point x ]) min.
 	^ boxPlotShape minYValue min: minYValueOfCurve.
+]
+
+{ #category : #initialization }
+RSViolinPlotShape >> model [
+	^ model
+]
+
+{ #category : #initialization }
+RSViolinPlotShape >> model: aModel [
+	model := aModel
 ]
 
 { #category : #initialization }

--- a/src/Roassal3-Chart/RSViolinPlotShape.class.st
+++ b/src/Roassal3-Chart/RSViolinPlotShape.class.st
@@ -33,6 +33,7 @@ RSViolinPlotShape >> bandOffset: aNumber [
 RSViolinPlotShape >> bandWidth: aNumber [
 	bandWidth := aNumber.
 	boxPlotShape bandWidth: bandWidth*0.1.
+	boxPlotShape outlierSize: bandWidth*0.05.
 ]
 
 { #category : #accessing }
@@ -160,6 +161,11 @@ RSViolinPlotShape >> model [
 { #category : #initialization }
 RSViolinPlotShape >> model: aModel [
 	model := aModel
+]
+
+{ #category : #initialization }
+RSViolinPlotShape >> outlierSize: aDimensionInPixels [
+	boxPlotShape outlierSize: aDimensionInPixels.
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
```smalltalk
| boxPlot1 toothGrowth |
toothGrowth := AIDatasets loadToothGrowth.
boxPlot1 := RSViolinPlot dataFrame: toothGrowth x: #dose y: #len.
boxPlot1 color: Color purple translucent.
"boxPlot1 bandwidth: 2."
^ boxPlot1 open
```
![image](https://github.com/ObjectProfile/Roassal3/assets/74360938/09a8693b-7dea-4cb4-a4ba-256fbc75652b)
