### PR TITLE
Plots work on projections on objects

### DIFF
--- a/src/Roassal3-Chart-Tests/RSAbstractPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSAbstractPlotTest.class.st
@@ -126,6 +126,15 @@ RSAbstractPlotTest >> testPaddingIsCorrect [
 ]
 
 { #category : #tests }
+RSAbstractPlotTest >> testRawdata [
+
+	| data |
+	data := { 0@1 . 1@3 . 2@3 . 3@5 . 4@6 }.
+	plot := self classToTest new rawData: data x: #x y: #y.
+	plot build
+]
+
+{ #category : #tests }
 RSAbstractPlotTest >> testStylerDefault [
 
 	| tick |

--- a/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
+++ b/src/Roassal3-Chart-Tests/RSBarPlotTest.class.st
@@ -55,6 +55,15 @@ RSBarPlotTest >> testBasic [
 	plot build
 ]
 
+{ #category : #tests }
+RSBarPlotTest >> testDoubleBarPlotRawData [
+
+	| data |
+	data := { #(1 2 3). #(2 3 4) . #(-3 5 -7) }.
+	plot := RSDoubleBarPlot new rawData: data x1: #first x2: #second y: #third.
+	plot build
+]
+
 { #category : #running }
 RSBarPlotTest >> testExtentIsCorrect [
 

--- a/src/Roassal3-Chart/RSAbstractPlot.class.st
+++ b/src/Roassal3-Chart/RSAbstractPlot.class.st
@@ -19,7 +19,8 @@ Class {
 		'chart',
 		'shape',
 		'xValues',
-		'yValues'
+		'yValues',
+		'rawData'
 	],
 	#category : #'Roassal3-Chart-Core'
 }
@@ -264,6 +265,13 @@ RSAbstractPlot >> minValueY [
 	"Return the minimum Y value of the plot, excluding NaN and infinite"
 
 	^ self definedValuesY min
+]
+
+{ #category : #public }
+RSAbstractPlot >> rawData: aCollection x: bloc1 y: bloc2 [
+
+	rawData := aCollection.
+	self x: (rawData collect: bloc1) y: (rawData collect: bloc2)
 ]
 
 { #category : #rendering }

--- a/src/Roassal3-Chart/RSDoubleBarPlot.class.st
+++ b/src/Roassal3-Chart/RSDoubleBarPlot.class.st
@@ -82,6 +82,16 @@ RSDoubleBarPlot >> initializeDecorations [
 	self addDecoration: horizontalTopTick
 ]
 
+{ #category : #public }
+RSDoubleBarPlot >> rawData: aCollection x1: bloc1 x2: bloc2 y: bloc3 [
+
+	rawData := aCollection.
+	self
+		x1: (rawData collect: bloc1)
+		x2: (rawData collect: bloc2)
+		y: (rawData collect: bloc3)
+]
+
 { #category : #rendering }
 RSDoubleBarPlot >> renderIn: canvas [
 

--- a/src/Roassal3-Chart/RSDoubleBarPlot.class.st
+++ b/src/Roassal3-Chart/RSDoubleBarPlot.class.st
@@ -19,7 +19,7 @@ RSDoubleBarPlot >> bars2 [
 	^ bars2
 ]
 
-{ #category : #public }
+{ #category : #'accessing - computed' }
 RSDoubleBarPlot >> computeSecondColor [
 	^ secondColor ifNil: [ self chart colorFor: x2Values ]
 ]
@@ -114,7 +114,7 @@ RSDoubleBarPlot >> secondColor [
 	^ secondColor
 ]
 
-{ #category : #accessing }
+{ #category : #public }
 RSDoubleBarPlot >> x1: x1 x2: x2 y: y [
 	self assert: x1 size = x2 size description: 'The two collections must have the same size'.
 	self x: x1 y: y.


### PR DESCRIPTION
Fixes #470
Added the possibility to build a plot with raw data. Be aware though that is doesn't work with all plots, only bar plots (use `rawData: x1: x2: y:` for `RSDoubleBarPlot`), line plots and scatter plots.

Example:
```Smalltalk
data := { 0@1 . 1@3 . 2@3 . 3@5 }.
p := RSLinePlot new rawData: data  x: #x y: #y .
p open
```
![image](https://github.com/ObjectProfile/Roassal3/assets/124769707/23285a1d-b61d-4742-a1c0-956faf274d19)
